### PR TITLE
Multi-garment VTO: requestVto + token-based Firestore subscription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,15 +50,35 @@ reuses the dev Firebase project.
 ## Frame URL rewriting
 
 Backend stores avatar and VTO frame URLs in Firestore as bare paths (e.g.
-`user-X/avatar-N/colorway-size-asset-M/frames/image_K.png`) — see the matching
-note in `tfr-backend/AGENTS.md`. The SDK prepends the configured `frames.baseUrl`
-(per-env in `config.ts`) at the consumption site. Helper: `applyFrameBaseUrl` in
-`src/lib/util.ts`. It also strips the host from any legacy host-prefixed URLs
-still present in older Firestore records, so both shapes work.
+`user-X/avatar-N/frames/image_K.png` for avatar, `user-X/avatar-N/vto-{token}/frames/image_K.png`
+for VTO compositions) — see the matching note in `tfr-backend/AGENTS.md`. The SDK
+prepends the configured `frames.baseUrl` (per-env in `config.ts`) at the
+consumption site. Helper: `applyFrameBaseUrl` in `src/lib/util.ts`. It also
+strips the host from any legacy host-prefixed URLs still present in older
+Firestore records, so both shapes work.
 
 Currently used in `src/components/overlays/vto-single.tsx` only. Anywhere else
 that turns a Firestore-supplied frame URL into an `<img src>` should call
 `applyFrameBaseUrl` too.
+
+## VTO request flow
+
+`requestVto(items)` in `src/lib/api.ts` posts a 1..4-garment composition to
+`/v1/vto-compositions` and returns `{token, status, composition_path}`. The
+SDK then subscribes to `users/{uid}/vto_compositions/{token}` via
+`FirestoreManager.listenToSubDoc` (in `src/lib/firebase.ts`) and renders
+frames as the backend webhook delivers them.
+
+`vto-single.tsx` keeps a per-component `compositionTokens: Map<csaKey, token>`
+to dedupe POSTs and a `vtoDocsByToken` state to hold the latest snapshot per
+token. `compositionKey(csaId, tucked)` is the dedup key — tucked is always
+`false` for single-garment, but the shape is forward-compatible with
+multi-garment when that lands. Subscriptions are torn down on unmount.
+
+Backend dedupes server-side by content hash, so re-requesting the same
+composition returns the same token without a sim-vis call. `useCache` on
+`execApiRequest` is intentionally **off** for this endpoint because the
+local cache is URL-keyed and the body now varies; backend dedup covers it.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,33 @@ For SDK-only changes, run `npm run watch-serve` and reload the demo
 storefront with `?tfr-source=local` — no theme push needed. For changes
 that touch the bootstrap script, callbacks, or markup, push to the
 `shopify` repo's `development` branch.
+
+---
+
+## Definition of done
+
+A change is not complete until every box below is checked. The `init` /
+gen / Firestore-conventions notes above are easy to drift from when
+files move or shapes change — keep AGENTS.md edits in the same change as
+the code they describe.
+
+- [ ] `npm run check` (tsc --noEmit) clean
+- [ ] `npm run build` produces `dist/index.js` without errors
+- [ ] If consumed any new or changed backend types: `npm run gen-types`
+      ran and the `src/api/gen/*` diff is committed in the same change
+- [ ] If a new `_init` step was added: ordered correctly in
+      `src/index.tsx`'s init sequence (logger → store → asset → theme →
+      view → firebase → api → product), and any module-scoped `let`
+      variable + accessor pattern is consistent with sibling modules
+- [ ] If a new Firestore subscription was added: an `Unsubscribe` is
+      tracked and torn down on unmount or auth-state change (see
+      `vto-single.tsx` token-keyed subscription map for the pattern)
+- [ ] Demo storefront round-trip verified with `?tfr-source=local` for any
+      user-visible change (or noted explicitly when the change can't be
+      visually verified)
+- [ ] **AGENTS.md updated** if the change touches: the build/release flow,
+      the gen-types boundary, the `_init` order, the frame URL contract,
+      the VTO request flow, the Zustand store conventions, or any specific
+      file/helper this file cites by name
+- [ ] **README.md updated** if the local-development workflow,
+      `npm run` scripts, or storefront integration changed

--- a/src/api/gen/requests.ts
+++ b/src/api/gen/requests.ts
@@ -300,23 +300,69 @@ export interface Joint {
   y: number /* float64 */;
   z: number /* float64 */;
 }
+/**
+ * Garment is one item within a multi-garment FramesRequest. Backend
+ * pre-sorts the garments slice by absolute layer order (StyleCategoryConfig
+ * LayerOrder, with LayerOrderTucked substituted when Tucked && Tuckable),
+ * then sets LayerOrder to the zero-based index in the sorted slice.
+ * Sim-vis renders garments in array order; the LayerOrder field is
+ * redundant-but-explicit.
+ */
+export interface Garment {
+  garment_id: number /* int64 */;
+  colorway_size_asset_id: number /* int64 */;
+  size_id: number /* int64 */;
+  asset_container_storage_path: string;
+  u3ma: string;
+  style_category_name: any /* enums.StyleCategory */;
+  sleeveless: boolean;
+  layer_order: number /* int */;
+  tucked: boolean;
+  placement_measurement_location: string;
+  placement_offset_y: number /* float64 */;
+}
+/**
+ * FramesRequest is the backend → sim-vis VTO request body. Top-level
+ * fields describe the user/avatar context; per-garment data lives in
+ * Garments. Sim-vis returns a token in its 202 response which becomes the
+ * routing key for the inbound webhook.
+ */
 export interface FramesRequest {
   user_id: string;
   avatar_id: number /* int64 */;
   gender: string;
-  garment_id: number /* int64 */;
-  colorway_id: number /* int64 */;
-  size_id: number /* int64 */;
   avatar_storage_path: string;
   sdf_storage_path: string;
-  asset_container_storage_path: string;
   hex_value: string;
   color_value: number /* float64 */;
   frame_count: number /* int64 */;
   joints: Joint[];
-  u3ma: string;
-  style_category_name: any /* enums.StyleCategory */;
-  sleeveless: boolean;
-  placement_measurement_location: string;
-  placement_offset_y: number /* float64 */;
+  garments: Garment[];
+}
+/**
+ * VtoCompositionItem is one entry in the SDK → backend POST body. The SDK
+ * passes items in any order; backend resolves the canonical render order
+ * before sending to sim-vis.
+ */
+export interface VtoCompositionItem {
+  colorway_size_asset_id: number /* int64 */;
+  tucked: boolean;
+}
+/**
+ * VtoCompositionRequest is the SDK → backend POST body. Backend enforces
+ * 1 <= len(Items) <= 4. Includes/Excludes composition rules are validated
+ * client-side; backend does not enforce them.
+ */
+export interface VtoCompositionRequest {
+  items: VtoCompositionItem[];
+}
+/**
+ * VtoCompositionWebhook is the sim-vis → backend webhook body. The token
+ * is in the URL path, not the body.
+ */
+export interface VtoCompositionWebhook {
+  avatar_id: number /* int64 */;
+  error: string;
+  frames_storage_path: string;
+  frame_count: number /* int */;
 }

--- a/src/api/gen/responses.ts
+++ b/src/api/gen/responses.ts
@@ -755,3 +755,20 @@ export interface FirestoreUser {
   is_gte_18: boolean;
   vto: { [key: string]: { [key: string]: FirestoreVTOData}}; // brand_id and colorway_sku index
 }
+
+//////////
+// source: vto.go
+
+/**
+ * VtoCompositionResponse is the SDK ← backend response from POST
+ * /v1/vto-compositions. The token is sim-vis's identifier (also the cache
+ * key); status is "pending" when the render is in flight, "ready" when
+ * the cache hit returned an already-rendered composition. composition_path
+ * is the Firestore document path the SDK should subscribe to with
+ * onSnapshot — `users/{uid}/vto_compositions/{token}`.
+ */
+export interface VtoCompositionResponse {
+  token: string;
+  status: string;
+  composition_path: string;
+}

--- a/src/components/overlays/vto-single.tsx
+++ b/src/components/overlays/vto-single.tsx
@@ -6,7 +6,7 @@ import { ModalTitlebar, SidecarModalFrame } from '@/components/modal'
 import { LinkT } from '@/components/link'
 import { Text, TextT } from '@/components/text'
 import {
-  requestVtoSingle as apiRequestVtoSingle,
+  requestVto as apiRequestVto,
   FitClassification,
   SizeFit,
 } from '@/lib/api'
@@ -20,7 +20,7 @@ import {
   InfoIcon,
   TfrNameSvg,
 } from '@/lib/asset'
-import { getAuthManager } from '@/lib/firebase'
+import { getAuthManager, getFirestoreManager } from '@/lib/firebase'
 import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
 import { loadProductDataToStore } from '@/lib/product'
@@ -66,6 +66,21 @@ const CONTENT_AREA_WIDTH_PX = 550
 
 const logger = getLogger('overlays/vto-single')
 
+// VtoFramesDoc mirrors the per-user vto_compositions/{token} doc the backend
+// writes. Only the fields the SDK consumes are typed here.
+type VtoFramesDoc = {
+  frames?: string[]
+  error?: string
+  status?: 'pending' | 'ready' | 'failed' | string
+}
+
+// compositionKey identifies a unique 1-garment composition for in-component
+// dedup (csaId + tucked). Tucked is always false for single-garment VTO; the
+// shape is kept tucked-aware for forward compatibility with multi-garment.
+function compositionKey(csaId: number, tucked: boolean): string {
+  return `${csaId}:${tucked ? 1 : 0}`
+}
+
 export default function VtoSingleOverlay() {
   const userIsLoggedIn = useMainStore((state) => state.userIsLoggedIn)
   const userHasAvatar = useMainStore((state) => state.userHasAvatar)
@@ -78,8 +93,16 @@ export default function VtoSingleOverlay() {
   const [selectedSizeLabel, setSelectedSizeLabel] = useState<string | null>(null)
   const [selectedColorLabel, setSelectedColorLabel] = useState<string | null>(null)
   const [modalStyle, setModalStyle] = useState<StyleProp>({})
-  const fetchedVtoSkus = useRef<Set<string>>(new Set())
-  const readyVtoSkus = useRef<Set<string>>(new Set())
+  // compositionKey → token returned by POST /v1/vto-compositions; serves as
+  // both dedup (don't re-POST for the same composition) and as the lookup
+  // key into vtoDocsByToken.
+  const compositionTokensRef = useRef<Map<string, string>>(new Map())
+  // token → latest Firestore subcollection doc (frames/status/error). Updated
+  // by the onSnapshot subscription that fires whenever the backend webhook
+  // writes to users/{uid}/vto_compositions/{token}.
+  const [vtoDocsByToken, setVtoDocsByToken] = useState<Record<string, VtoFramesDoc>>({})
+  // token → unsubscribe handle; cleaned up on unmount.
+  const subscriptionsRef = useRef<Map<string, () => void>>(new Map())
   const lastPriorityVtoRequestTimeRef = useRef<number | null>(null)
 
   // Redirect if not logged in or no avatar
@@ -107,7 +130,7 @@ export default function VtoSingleOverlay() {
   useEffect(() => {
     async function setupInitialVtoData() {
       try {
-        const { brandId, currentProduct } = getStaticData()
+        const { currentProduct } = getStaticData()
         if (!currentProduct) {
           return
         }
@@ -217,11 +240,9 @@ export default function VtoSingleOverlay() {
           setSelectedColorLabel(recommendedColorLabel)
         }
 
-        // Mark already available VTO SKUs as fetched/ready
-        for (const sku in userProfile?.vto?.[brandId] ?? {}) {
-          fetchedVtoSkus.current.add(sku)
-          readyVtoSkus.current.add(sku)
-        }
+        // (Legacy `userProfile.vto[brandId][sku]` ready-marking removed:
+        // tokens are tracked per session against the new vto_compositions
+        // subcollection, populated as the user navigates colors/sizes.)
       } catch (error) {
         logger.logError('Error fetching initial data:', { error })
         setVtoProductData(false)
@@ -249,19 +270,31 @@ export default function VtoSingleOverlay() {
     return { sizeColorRecord, availableColorLabels }
   }, [vtoProductData, selectedSizeLabel, selectedColorLabel])
 
-  // Fetch VTO data for a color/size
+  // Fetch VTO data for a color/size. Posts a 1-item composition request,
+  // captures the returned token, and starts an onSnapshot subscription to
+  // the per-user `vto_compositions/{token}` Firestore doc so frame URLs
+  // arrive reactively when the backend webhook completes.
   const requestVto = useCallback((sizeColorRecord: VtoSizeColorData, priority: boolean) => {
-    if (fetchedVtoSkus.current.has(sizeColorRecord.sku)) {
+    const csaId = sizeColorRecord.colorwaySizeAssetId
+    const key = compositionKey(csaId, false)
+    if (compositionTokensRef.current.has(key)) {
       return
     }
     function executeRequest() {
       logger.timerStart(`requestVto_${sizeColorRecord.sku}`)
       logger.logDebug(`{{ts}} - Requesting VTO for sku: ${sizeColorRecord.sku}`, { priority, sizeColorRecord })
-      fetchedVtoSkus.current.add(sizeColorRecord.sku)
+      // Mark in-flight before the POST resolves to dedupe re-entrant calls.
+      compositionTokensRef.current.set(key, '')
 
-      apiRequestVtoSingle(sizeColorRecord.colorwaySizeAssetId).catch((error) => {
-        logger.logError(`Error requesting VTO for sku: ${sizeColorRecord.sku}`, { error, sizeColorRecord })
-      })
+      apiRequestVto([{ colorway_size_asset_id: csaId, tucked: false }])
+        .then((resp) => {
+          compositionTokensRef.current.set(key, resp.token)
+          subscribeToCompositionToken(resp.token, sizeColorRecord.sku)
+        })
+        .catch((error) => {
+          logger.logError(`Error requesting VTO for sku: ${sizeColorRecord.sku}`, { error, sizeColorRecord })
+          compositionTokensRef.current.delete(key)
+        })
     }
     if (NON_PRIORITY_VTO_REQUEST_DELAY_MS) {
       let delay: number = 0
@@ -285,6 +318,49 @@ export default function VtoSingleOverlay() {
     executeRequest()
   }, [])
 
+  // Subscribe to a vto_compositions/{token} Firestore doc. Idempotent:
+  // re-subscribing for the same token is a no-op. Subscriptions are torn
+  // down on unmount via subscriptionsRef.
+  const subscribeToCompositionToken = useCallback((token: string, sku: string) => {
+    if (subscriptionsRef.current.has(token)) {
+      return
+    }
+    const authManager = getAuthManager()
+    const uid = authManager.getAuthUser()?.uid
+    if (!uid) {
+      logger.logWarn(`subscribe to vto composition skipped: no uid`, { token, sku })
+      return
+    }
+    const unsub = getFirestoreManager().listenToSubDoc<VtoFramesDoc>(
+      'users',
+      uid,
+      'vto_compositions',
+      token,
+      (data) => {
+        if (data && data.frames && data.frames.length > 0) {
+          logger.timerEnd(`requestVto_${sku}`)
+          logger.logTimer(`requestVto_${sku}`, `{{ts}} - VTO data is loaded for sku: ${sku}`)
+        }
+        setVtoDocsByToken((prev) => ({ ...prev, [token]: data ?? {} }))
+      },
+    )
+    subscriptionsRef.current.set(token, unsub)
+  }, [])
+
+  // Tear down all VTO subscriptions on unmount.
+  useEffect(() => {
+    return () => {
+      subscriptionsRef.current.forEach((unsub) => {
+        try {
+          unsub()
+        } catch (e) {
+          logger.logError('Error unsubscribing from vto composition', { error: e })
+        }
+      })
+      subscriptionsRef.current.clear()
+    }
+  }, [])
+
   // Trigger priority VTO request when size/color selection changes
   useEffect(() => {
     if (selectedColorSizeRecord) {
@@ -305,39 +381,25 @@ export default function VtoSingleOverlay() {
     }
   }, [requestVto, vtoProductData, selectedColorLabel])
 
-  // Lookup VTO frames for selected color/size from user profile
+  // Lookup VTO frames for the currently-selected color/size by mapping
+  // (csaId, tucked=false) → token → vtoDocsByToken[token]. Frames are
+  // populated reactively as the Firestore subscription receives updates.
   const vtoData = useMemo(() => {
-    if (!userProfile || !selectedColorSizeRecord) {
+    if (!selectedColorSizeRecord) {
       return null
     }
-
-    // Lookup VTO data from user profile
-    const { brandId } = getStaticData()
-    const availableSkuData = userProfile.vto?.[brandId]
-    if (!availableSkuData) {
+    const key = compositionKey(selectedColorSizeRecord.colorwaySizeAssetId, false)
+    const token = compositionTokensRef.current.get(key)
+    if (!token) {
       return null
     }
-
-    // Track VTO performance
-    if (logger.isDebugEnabled()) {
-      for (const sku of fetchedVtoSkus.current) {
-        if (!readyVtoSkus.current.has(sku) && availableSkuData[sku]) {
-          readyVtoSkus.current.add(sku)
-          logger.timerEnd(`requestVto_${sku}`)
-          logger.logTimer(`requestVto_${sku}`, `{{ts}} - VTO data is loaded for sku: ${sku}`)
-        }
-      }
-    }
-
-    // Lookup selected SKU (color/size) VTO data
-    const vtoData = availableSkuData[selectedColorSizeRecord.sku]
-    if (!vtoData) {
+    const doc = vtoDocsByToken[token]
+    if (!doc || !doc.frames || doc.frames.length === 0) {
       return null
     }
-
     logger.logDebug(`{{ts}} - Displaying VTO for sku: ${selectedColorSizeRecord.sku}`)
-    return vtoData
-  }, [selectedColorSizeRecord, userProfile])
+    return doc
+  }, [selectedColorSizeRecord, vtoDocsByToken])
 
   // Rewrite firestore-supplied frame URLs to the configured frames base URL,
   // then preload the resulting images

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,7 @@ import {
   Size,
   SizeFit as GenSizeFit,
   SizeFitRecommendation as GenSizeFitRecommendation,
+  VtoCompositionResponse,
 } from '@/api/gen/responses'
 import { getAuthManager } from '@/lib/firebase'
 import { getStaticData, useMainStore } from '@/lib/store'
@@ -151,11 +152,23 @@ export async function getSizeRecommendation(styleId: number): Promise<SizeFitRec
   })
 }
 
-export async function requestVtoSingle(colorwaySizeAssetId: number) {
-  await execApiRequest<void>({
-    useCache: true, // although this is a POST, we only want to send it once
+export type VtoCompositionItem = {
+  colorway_size_asset_id: number
+  tucked?: boolean
+}
+
+// requestVto dispatches a 1..4-garment VTO composition. Backend dedupes by
+// content hash so re-requesting the same composition returns the same
+// token without a sim-vis call. The returned token is the routing key for
+// the rendered Firestore doc — subscribe to it via subscribeToVtoComposition.
+//
+// useCache is off because the cache is URL-keyed and this endpoint's body
+// varies per call. Backend server-side dedup handles the same scenario.
+export async function requestVto(items: VtoCompositionItem[]): Promise<VtoCompositionResponse> {
+  return await execApiRequest<VtoCompositionResponse>({
     useToken: true,
     method: 'POST',
-    endpoint: `/v1/colorway-size-assets/${colorwaySizeAssetId}/frames`,
+    endpoint: '/v1/vto-compositions',
+    body: { items },
   })
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -100,6 +100,25 @@ export class FirestoreManager {
     return unsubscribe
   }
 
+  // listenToSubDoc subscribes to <parent>/<parentID>/<sub>/<subID>. Used for
+  // VTO compositions which live at users/{uid}/vto_compositions/{token}.
+  public listenToSubDoc<T extends DocumentData = DocumentData>(
+    parent: string,
+    parentID: string,
+    sub: string,
+    subID: string,
+    callback: (data: T | null) => void,
+  ): Unsubscribe {
+    const docRef = doc(this.firestore, parent, parentID, sub, subID)
+    return onSnapshot(docRef, (snap) => {
+      if (snap.exists()) {
+        callback(snap.data() as T)
+      } else {
+        callback(null)
+      }
+    })
+  }
+
   public async queryDocs<T extends DocumentData = DocumentData>(
     collectionName: string,
     constraints: QueryFieldFilterConstraint[],


### PR DESCRIPTION
## Summary

SDK companion to the backend multi-garment VTO change (TheFittingRoom/tfr-backend#836).

- `requestVtoSingle(csaId)` → `requestVto(items)` posting to `/v1/vto-compositions` with a 1..4-garment list. Returns `{token, status, composition_path}`.
- New `FirestoreManager.listenToSubDoc` helper for `users/{uid}/vto_compositions/{token}` onSnapshot subscriptions.
- `vto-single.tsx` rewritten:
  - Per-component state: `compositionTokens: Map<csaKey, token>` for dedup + lookup
  - Per-component state: `vtoDocsByToken: Record<token, VtoFramesDoc>` populated reactively from Firestore
  - Subscription per token, torn down on unmount
  - Legacy `userProfile.vto[brand][sku]` reads removed
- Single-garment is sent as a 1-item composition with `tucked: false`. The `compositionKey(csaId, tucked)` shape is forward-compatible with multi-garment when that lands.
- `src/api/gen/*` regenerated from updated backend types.

## Test plan

- [x] `npm run check` (tsc) clean
- [x] `npm run build` produces `dist/index.js` (1.67 MB)
- [x] Type regen idempotent
- [ ] Demo storefront with `?tfr-source=local`: single-garment VTO renders against the new flow (manual verification once backend PR lands)

## Coordination

Depends on TheFittingRoom/tfr-backend#836 landing first — the new `/v1/vto-compositions` endpoint and `users/{uid}/vto_compositions/{token}` subcollection live there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)