### PR TITLE
Fix dev.yaml: merge guard + chore skip

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -20,13 +20,21 @@ permissions:
   contents: write
 
 jobs:
+  # Only run on merged PRs (not on close-without-merge) or manual dispatch.
+  # `pull_request_target: closed` fires on both, so we have to filter here.
   get_version_label:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: ./.github/workflows/get-version-label.yaml
     with:
       workflow_dispatch_version_label: ${{ github.event.inputs.workflow_dispatch_version_label }}
   build:
     needs: [get_version_label]
-    if: needs.get_version_label.result == 'success'
+    # Skip the bump+publish job entirely when the PR is labeled `chore`.
+    # The label still has to be present (get-version-label.yaml enforces
+    # exactly one of patch/minor/major/chore), but `chore` signals "no
+    # release for this PR" — `npm version chore` isn't a valid command,
+    # so we have to gate the job rather than try to run it.
+    if: needs.get_version_label.result == 'success' && needs.get_version_label.outputs.version_label != 'chore'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Two bugs in `.github/workflows/dev.yaml` (the auto-release workflow that fires on PR close):

1. **Missing merge guard.** `pull_request_target: closed` fires on both merges *and* close-without-merge. Cancelling a PR previously still triggered the bump+publish path. Adds `if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true` to the `get_version_label` job.

2. **Broken `chore` handling.** `get-version-label.yaml` accepts `chore` as a valid PR label so the PR check passes — but `dev.yaml` then runs `npm version chore`, which is not a valid `npm version` argument and fails the step. The intent of `chore` is "no release for this PR" so the fix is to gate the `build` job on `version_label != 'chore'` and let the whole job skip cleanly.

This PR is itself labeled `chore`, so it exercises the new skip path: if the workflow runs correctly, the entire `Deploy To Dev` workflow should be skipped on merge (no failed npm version step, no version bump, no publish attempt).

## Test plan

- [x] yaml is structurally valid (`gh` accepted it; same syntax as the rest of the file)
- [ ] On merge: GitHub Actions shows the `Deploy To Dev` workflow either not triggered, or with the build job skipped — neither of which leaves a red/failed run
- [ ] No version bump on `package.json` after merge
- [ ] No new git tag pushed after merge

## Note on the npm publish 404

Separately, the npm publish step has been failing with `PUT 404 https://registry.npmjs.org/@thefittingroom%2fshop-ui` — that's an auth issue (npm returns 404 instead of 401/403 on scoped packages when the token is missing/wrong scope). Diagnosis is to verify `NPM_TOKEN` is current and has read+write access to `@thefittingroom/*`. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)