### PR TITLE
Drop unnecessary checkout from get-version-label workflow

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -20,13 +20,21 @@ permissions:
   contents: write
 
 jobs:
+  # Only run on merged PRs (not on close-without-merge) or manual dispatch.
+  # `pull_request_target: closed` fires on both, so we have to filter here.
   get_version_label:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: ./.github/workflows/get-version-label.yaml
     with:
       workflow_dispatch_version_label: ${{ github.event.inputs.workflow_dispatch_version_label }}
   build:
     needs: [get_version_label]
-    if: needs.get_version_label.result == 'success'
+    # Skip the bump+publish job entirely when the PR is labeled `chore`.
+    # The label still has to be present (get-version-label.yaml enforces
+    # exactly one of patch/minor/major/chore), but `chore` signals "no
+    # release for this PR" — `npm version chore` isn't a valid command,
+    # so we have to gate the job rather than try to run it.
+    if: needs.get_version_label.result == 'success' && needs.get_version_label.outputs.version_label != 'chore'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/get-version-label.yaml
+++ b/.github/workflows/get-version-label.yaml
@@ -24,17 +24,11 @@ jobs:
     outputs:
       version_label: ${{ steps.get_version_label.outputs.version_label }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: "https://registry.npmjs.org"
-          cache: "npm"
-
+      # No checkout/setup-node needed — labels come from the webhook event
+      # payload (context.payload.pull_request.labels), not from the repo.
+      # Earlier versions checked out github.event.pull_request.head.ref,
+      # which fails on close events when the head branch has been deleted
+      # (manually or via auto-delete-on-merge).
       - name: Determine version label
         id: get_version_label
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Third latent bug in the release workflow chain (after #46's merge guard + chore skip). The `get_version_label` job was running `actions/checkout` against `github.event.pull_request.head.ref` — but the script that follows only reads `context.payload.pull_request.labels`, which comes from the webhook event payload, not from any checked-out file. The checkout was a no-op for what the script does.

It became an active liability when:

1. A PR is merged
2. The head branch is deleted (auto-delete-on-merge or manual cleanup)
3. `Deploy To Dev` fires on the close event
4. `get_version_label` runs → `actions/checkout` tries to resolve the now-deleted ref → fails

This is what produced the red Actions run after #46 merged: the chore-skip code path I added in #46 worked correctly for the *build* job, but the *get_version_label* job itself errored out before it could pass the label downstream.

Drop the checkout (and the unused `setup-node` step alongside it). The label is read directly from the event payload regardless of whether the head branch still exists.

## Test plan

This PR is itself labeled `chore` and the head branch will be deleted on merge — so the merge serves as a live test of the fix:

- [ ] On merge: `get_version_label` succeeds (no "branch could not be found" error)
- [ ] On merge: `Deploy To Dev` skips the `build` job per #46's chore skip
- [ ] No red Actions run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)