### PR TITLE
Fix stale MinIO reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ Run the SDK against the local backend stack from
    The `?tfr-source=local` query param tells the storefront's `tfr.js` to load
    the SDK from `http://localhost:5173/dist/index.js` instead of jsdelivr, and
    to initialize it with `environment: 'local'` (see `src/lib/config.ts` —
-   that env points at `http://localhost:8080` for the API and the local MinIO
-   bucket for assets).
+   that env points at `http://localhost:8080` for the API and the local
+   s3proxy bucket for assets at `http://localhost:9000`).
 
 Reload the storefront page after a rebuild to pick up changes.
 


### PR DESCRIPTION
## Summary

local-deployment migrated from MinIO to `andrewgaul/s3proxy` for local S3 (see `local-deployment/AGENTS.md` "Workarounds" section for the underlying reason — virtiofs CRC race in MinIO under heavy concurrent multipart writes). This README's local-development walkthrough still mentioned MinIO. Swap to s3proxy and add the `:9000` port for clarity.

Behaviorally a docs-only change.

## Why this is labeled `patch`

This PR is also serving as the **first live test** of the new release pipeline (PR #49). On merge:

- `dev.yaml` should fire (PR was merged)
- `get_version_label` should pass with `patch`
- `build` job should run, bump `5.0.13` → `5.0.14`, push the tag, and **publish to npm via OIDC trusted publishing** under dist-tag `next`
- The `5.0.14` build should appear on https://www.npmjs.com/package/@thefittingroom/shop-ui under `next`, with a provenance attestation tying it to this commit

If the publish 404s again, the trusted publisher config on npmjs.com is the place to recheck. If it succeeds, the long-running NPM_TOKEN saga is over.

## Test plan

- [ ] On merge: `Deploy To Dev` workflow succeeds end-to-end
- [ ] `package.json` on `main` shows `5.0.14`
- [ ] `git tag` includes `v5.0.14`
- [ ] `npm view @thefittingroom/shop-ui dist-tags` shows `next: 5.0.14`
- [ ] `npm view @thefittingroom/shop-ui@5.0.14 --json` includes a `_attestations` / provenance entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)