### PR TITLE
OIDC publish belt-and-suspenders: scope on setup-node, publishConfig

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -46,6 +46,11 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+          # `scope` writes `@thefittingroom:registry=...` into the
+          # generated .npmrc so the npm CLI definitively routes scoped
+          # publishes to the right registry, which some OIDC code paths
+          # rely on. Belt-and-suspenders for trusted publishing.
+          scope: "@thefittingroom"
           cache: "npm"
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "engines": {
     "node": ">=22"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary

Two small additions to rule out commonly-cited misconfigs for OIDC trusted publishing of scoped packages, in case the persistent `package not found` 404 has a contributing cause beyond the npm-side trusted publisher entry:

1. **`setup-node` step gets `scope: "@thefittingroom"`.** This writes `@thefittingroom:registry=https://registry.npmjs.org/` into the generated `.npmrc`, ensuring the npm CLI routes the scoped publish through the right registry resolver. Some OIDC code paths look up trust based on the registry the publish call resolves against; without an explicit scope line, edge cases can resolve weirdly.

2. **`package.json` gets `publishConfig: { access: "public" }`.** We already pass `--access public` on the CLI, but having it in `publishConfig` is the canonical home for it. Belt-and-suspenders.

Neither changes business logic. Both are widely recommended on npm trusted-publishing setup guides for scoped packages.

## Why this PR is `patch`-labeled

Like #50, this is a live test of the publish pipeline. With trusted publishing now correctly set up on the npm side (per your latest verification), this should:
1. Bump 5.0.15 → 5.0.16
2. Push tag v5.0.16
3. **OIDC token exchange should now succeed** (the addition of `scope` may help; the form-being-truly-saved on npm side is the load-bearing factor)
4. Publish 5.0.16 to dist-tag `next` with provenance

## If this also fails

Two avenues left:

- **Confirm the npm trusted publisher truly persists.** Open the trusted-publisher page in a fresh incognito window — does it render the saved entry, or an empty/draft form? An empty form here means the save didn't stick.
- **Try a different trigger.** As a last resort, switch the publish step from `pull_request_target: closed` to a `push: tags: 'v*'` trigger. npm's docs example shows a tag-based trigger; while this *shouldn't* matter, some validators may treat tag-pushes differently.

But I really do think it's the trusted-publisher entry not actually being saved, even though the form shows the values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)