### PR TITLE
Use SDK_PUSH_PAT in checkout so tag push fires publish.yaml

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -48,10 +48,18 @@ jobs:
     if: needs.get_version_label.result == 'success' && needs.get_version_label.outputs.version_label != 'chore'
     runs-on: ubuntu-latest
     steps:
+      # `token:` is what actually controls the credentials git uses for
+      # pushes downstream (via extraheader in .git/config). Setting an
+      # env GITHUB_TOKEN on the push step itself is ignored — git's
+      # auth is already locked in from checkout. SDK_PUSH_PAT is a real
+      # PAT, which is required so the resulting tag push fires
+      # publish.yaml. GITHUB_TOKEN-authored pushes don't fire downstream
+      # workflows by GitHub design (loop prevention).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ secrets.SDK_PUSH_PAT }}
 
       - uses: actions/setup-node@v6
         with:
@@ -65,10 +73,5 @@ jobs:
       - name: Bump version
         run: npm version "${{ needs.get_version_label.outputs.version_label }}"
 
-      # Push using SDK_PUSH_PAT so the resulting tag push fires
-      # publish.yaml. GITHUB_TOKEN-pushed tags don't trigger workflows.
       - name: Push version + tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.SDK_PUSH_PAT }}
-        run: |
-          git push origin main --follow-tags
+        run: git push origin main --follow-tags

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,15 @@ on:
   push:
     tags:
       - "v*"
+  # Manual fallback: trigger from the Actions tab against any existing
+  # tag. Useful when dev.yaml pushed a tag but the chain broke and the
+  # publish never fired.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v5.0.16)"
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -23,10 +32,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # On push: github.ref is the tag ref (refs/tags/vX.Y.Z) — checkout
+       # uses it directly. On workflow_dispatch: the user-supplied tag
+       # input wins.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

#52's split-publish design was right architecturally but incomplete: `dev.yaml`'s tag push went out under `GITHUB_TOKEN` credentials, not `SDK_PUSH_PAT`. Result: `v5.0.16` tag was pushed but `publish.yaml` never fired (GitHub Actions deliberately suppresses workflow runs from `GITHUB_TOKEN`-authored pushes to prevent loops).

**The footgun:** setting `env: GITHUB_TOKEN: ${{ secrets.SDK_PUSH_PAT }}` on a `git push` step does nothing — `actions/checkout` has already locked in git credentials via `.git/config` `extraheader` using whatever token was in scope at checkout time. The push uses those stored credentials regardless of env overrides.

**The fix:** pass `SDK_PUSH_PAT` into `actions/checkout` itself via `token:`, so credentials are PAT-authored from the start.

```yaml
- uses: actions/checkout@v6
  with:
    fetch-depth: 0
    ref: main
    token: ${{ secrets.SDK_PUSH_PAT }}   # ← the load-bearing line
```

## Also adds: `workflow_dispatch` to `publish.yaml`

Manual recovery valve: if the `dev.yaml → publish.yaml` chain ever breaks again, you can trigger `publish.yaml` from the Actions tab against any existing tag (`v5.0.16`, etc.) without bumping another version. The checkout ref handles both `push: tags` (uses `github.ref`) and `workflow_dispatch` (uses the supplied `tag` input).

## Recovery for v5.0.16 (the orphaned tag from #52's merge)

After this PR merges, two paths to actually publish `5.0.16`:

**Option A: manual `workflow_dispatch`** (immediate, no churn)
- Actions tab → "Publish to npm" → Run workflow → tag: `v5.0.16` → Run

**Option B: merge another `patch` PR** (bumps to 5.0.17, leaves 5.0.16 phantom)

Option A is cleaner since it avoids a phantom and serves as the live test of the manual fallback path.

## Required: SDK_PUSH_PAT must have `workflow` scope

The PAT needs `workflow` scope for it to push tags that trigger workflows. If `SDK_PUSH_PAT` was created without that scope, the chain still won't fire even after this fix. To verify: GitHub → Settings → Developer settings → Personal access tokens → SDK_PUSH_PAT → check the scope list. If `workflow` isn't there, regenerate with that scope and update the GH repo secret.

## Test plan

- [x] yaml syntax valid for both workflows
- [ ] On merge: `dev.yaml` skips (this PR is `chore`-labeled, no bump)
- [ ] After merge: trigger `publish.yaml` via workflow_dispatch with tag `v5.0.16`
  - [ ] OIDC publish succeeds
  - [ ] `npm view @thefittingroom/shop-ui dist-tags` shows `next: 5.0.16`

## Phantom-version status (unchanged from #52's PR)

`next: 5.0.12`, `latest: 3.2.2`. Phantom git tags: `v5.0.13` through `v5.0.16`. Manual workflow_dispatch on `v5.0.16` would fix this and put `5.0.16` on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)