### PR TITLE
Add repository field to package.json (npm provenance requires it)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "the fitting room UI library",
   "type": "module",
   "main": "./dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheFittingRoom/shop-sdk-ui.git"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Manual `publish.yaml` run for `v5.0.16` got further than ever — full OIDC chain succeeded, provenance signed, npm just hard-rejected the publish with a 422:

```
Error verifying sigstore provenance bundle:
Failed to validate repository information:
package.json: "repository.url" is "",
expected to match "https://github.com/TheFittingRoom/shop-sdk-ui" from provenance
```

When `--provenance` is set on `npm publish`, the registry validates that `package.json#repository.url` matches the source repo embedded in the provenance attestation. Our `package.json` had no `repository` field at all → empty string → fails the equality check.

Adds:
```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/TheFittingRoom/shop-sdk-ui.git"
}
```

The `git+https://` form is the npm-standard prefix for git repos; npm normalizes it to `https://github.com/...` for the comparison against the provenance-recorded URL.

## Why this is the only OIDC-chain blocker left to fix

We've now incrementally verified every other piece of the chain:

| Step | Status |
|---|---|
| Trusted publisher entry on npm | ✅ Saved, points at `publish.yaml` |
| OIDC token mint from GitHub | ✅ Token returned (200) |
| OIDC token exchange at npm | ✅ 201 (was 404 before publish.yaml split) |
| Provenance signature | ✅ Pushed to sigstore (logIndex 1497321088) |
| Final `PUT /package` | ❌ 422: missing `repository.url` ← **this PR** |

After this lands, manually re-trigger `publish.yaml` for `v5.0.16` (Actions tab → "Publish to npm" → Run workflow → tag: `v5.0.16`). That should finally land `5.0.16` on npm.

## Test plan

- [x] `package.json` is valid JSON
- [x] `tsc --noEmit` clean
- [ ] After merge: workflow_dispatch `publish.yaml` against `v5.0.16` → publishes to npm

## Note: `SDK_PUSH_PAT` issue is separate and still unresolved

This PR doesn't touch the missing/empty `SDK_PUSH_PAT` situation. Auto-merge-driven releases will still fail at `actions/checkout` until that secret is properly populated. But fixing this PR + getting `5.0.16` out via the manual fallback path is independently valuable, and decouples the two problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)