### PR TITLE
Make VTO prefetch delay configurable; cancel stale prefetch timers

### DIFF
--- a/src/components/overlays/fitting-room/use-vto-requests.ts
+++ b/src/components/overlays/fitting-room/use-vto-requests.ts
@@ -1,15 +1,10 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { requestVto as apiRequestVto, VtoCompositionItem } from '@/lib/api'
 import { getLogger } from '@/lib/logger'
 import { getStaticData } from '@/lib/store'
 import { applyFrameBaseUrl } from '@/lib/util'
 
 const logger = getLogger('overlays/fitting-room/use-vto-requests')
-
-// Throttle non-priority requests behind the most-recent priority one so the
-// pre-warm alternates don't crowd the user's actively-selected outfit. Mirrors
-// vto-single's NON_PRIORITY_VTO_REQUEST_DELAY_MS.
-const NON_PRIORITY_REQUEST_DELAY_MS = 500
 
 // outfitKey is the dedup / lookup key for a composition. Sorted to normalize
 // item ordering so two outfits with identical (csa, untucked) tuples in
@@ -23,9 +18,10 @@ export function outfitKey(items: VtoCompositionItem[]): string {
 
 export interface UseVtoRequestsHandle {
   // Fire a /v1/vto-compositions POST if this outfit hasn't been requested yet.
-  // priority=true marks this as the user-active outfit and resets the
-  // non-priority throttle; priority=false fires pre-warm alternates that may
-  // get delayed up to NON_PRIORITY_REQUEST_DELAY_MS.
+  // priority=true marks this as the user-active outfit, cancels any pending
+  // (still-queued) prefetch requests, and resets the non-priority throttle;
+  // priority=false fires pre-warm alternates that may get delayed up to
+  // config.api.vtoPrefetchDelayMs.
   request: (items: VtoCompositionItem[], priority: boolean) => void
   // Return rewritten (base-URL-applied) frame URLs for the given outfit, or
   // null when not ready / not yet requested.
@@ -45,6 +41,9 @@ export function useVtoRequests(): UseVtoRequestsHandle {
   // outfitKeys already requested (in-flight or completed) — dedup
   const requestedKeysRef = useRef<Set<string>>(new Set())
   const lastPriorityTimeRef = useRef<number | null>(null)
+  // Queued-but-not-yet-fired prefetch timers. A new priority request clears
+  // these so stale alternates from the previous selection never go out.
+  const pendingPrefetchTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
   const [lastError, setLastError] = useState<Error | null>(null)
 
   const clearError = useCallback(() => setLastError(null), [])
@@ -71,21 +70,42 @@ export function useVtoRequests(): UseVtoRequestsHandle {
     }
 
     if (priority) {
+      // The selection changed — drop prefetch timers queued for the previous
+      // outfit so they don't fire after this priority request.
+      for (const timer of pendingPrefetchTimersRef.current) clearTimeout(timer)
+      pendingPrefetchTimersRef.current.clear()
       lastPriorityTimeRef.current = Date.now()
       exec()
       return
     }
+    // Throttle non-priority requests behind the most-recent priority one so
+    // the pre-warm alternates don't crowd the user's actively-selected
+    // outfit. The delay floor is config-driven (config.api.vtoPrefetchDelayMs).
     const last = lastPriorityTimeRef.current
     let delay = 0
     if (last) {
       const now = Date.now()
-      const minNext = last + NON_PRIORITY_REQUEST_DELAY_MS
+      const minNext = last + getStaticData().config.api.vtoPrefetchDelayMs
       if (now < minNext) delay = minNext - now
     }
     if (delay > 0) {
-      setTimeout(exec, delay)
+      const timer = setTimeout(() => {
+        pendingPrefetchTimersRef.current.delete(timer)
+        exec()
+      }, delay)
+      pendingPrefetchTimersRef.current.add(timer)
     } else {
       exec()
+    }
+  }, [])
+
+  // Drop any still-queued prefetch timers when the overlay unmounts so they
+  // don't fire POSTs (or setState) after teardown.
+  useEffect(() => {
+    const timers = pendingPrefetchTimersRef.current
+    return () => {
+      for (const timer of timers) clearTimeout(timer)
+      timers.clear()
     }
   }, [])
 

--- a/src/components/overlays/vto-single.tsx
+++ b/src/components/overlays/vto-single.tsx
@@ -36,7 +36,6 @@ interface ElementSize {
   height: number
 }
 
-const NON_PRIORITY_VTO_REQUEST_DELAY_MS: number | false = 500
 const AVATAR_IMAGE_ASPECT_RATIO = 2 / 3 // width:height
 const AVATAR_GUTTER_HEIGHT_PX = 100
 const CONTENT_AREA_WIDTH_PX = 550
@@ -262,24 +261,25 @@ export default function VtoSingleOverlay() {
           requestedKeysRef.current.delete(key)
         })
     }
-    if (NON_PRIORITY_VTO_REQUEST_DELAY_MS) {
-      let delay: number = 0
-      if (priority) {
-        lastPriorityVtoRequestTimeRef.current = Date.now()
-      } else {
-        const lastPriorityTime = lastPriorityVtoRequestTimeRef.current
-        if (lastPriorityTime) {
-          const now = Date.now()
-          const minNextRequestTime = lastPriorityTime + NON_PRIORITY_VTO_REQUEST_DELAY_MS
-          if (now < minNextRequestTime) {
-            delay = minNextRequestTime - now
-          }
+    // Throttle non-priority (prefetch) requests behind the most-recent
+    // priority one. The delay floor is config-driven
+    // (config.api.vtoPrefetchDelayMs); 0 fires immediately.
+    let delay: number = 0
+    if (priority) {
+      lastPriorityVtoRequestTimeRef.current = Date.now()
+    } else {
+      const lastPriorityTime = lastPriorityVtoRequestTimeRef.current
+      if (lastPriorityTime) {
+        const now = Date.now()
+        const minNextRequestTime = lastPriorityTime + getStaticData().config.api.vtoPrefetchDelayMs
+        if (now < minNextRequestTime) {
+          delay = minNextRequestTime - now
         }
       }
-      if (delay) {
-        setTimeout(executeRequest, delay)
-        return
-      }
+    }
+    if (delay) {
+      setTimeout(executeRequest, delay)
+      return
     }
     executeRequest()
   }, [])

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,6 +13,11 @@ export interface Config {
     // Client-side abort timeout (ms) for the synchronous VTO request, which
     // blocks while the backend renders. Guards against a hung backend.
     vtoTimeoutMs: number
+    // Delay (ms) before speculative VTO prefetch requests fire, measured from
+    // the most recent priority request. Keeps prefetch traffic from crowding
+    // the user's actively-selected render. 0 = fire immediately. Only takes
+    // effect when features.vtoPrefetch is true.
+    vtoPrefetchDelayMs: number
     // avatarTimeoutMs: number
   }
   asset: {
@@ -71,6 +76,7 @@ const CONFIGS: Record<EnvName, Config> = {
     api: {
       baseUrl: 'https://tfr.dev.thefittingroom.xyz',
       vtoTimeoutMs: 120000,
+      vtoPrefetchDelayMs: 3000,
     },
     asset: {
       baseUrl: 'https://assets.dev.thefittingroom.xyz/shop-sdk/assets/v5',
@@ -79,7 +85,7 @@ const CONFIGS: Record<EnvName, Config> = {
       baseUrl: 'https://assets.dev.thefittingroom.xyz',
     },
     features: {
-      vtoPrefetch: false,
+      vtoPrefetch: true,
     },
     ...SHARED_CONFIG,
   },
@@ -96,6 +102,7 @@ const CONFIGS: Record<EnvName, Config> = {
     api: {
       baseUrl: 'https://tfr.p.thefittingroom.xyz',
       vtoTimeoutMs: 120000,
+      vtoPrefetchDelayMs: 3000,
     },
     asset: {
       baseUrl: 'https://assets.p.thefittingroom.xyz/shop-sdk/assets/v5',
@@ -104,7 +111,7 @@ const CONFIGS: Record<EnvName, Config> = {
       baseUrl: 'https://assets.p.thefittingroom.xyz',
     },
     features: {
-      vtoPrefetch: false,
+      vtoPrefetch: true,
     },
     ...SHARED_CONFIG,
   },
@@ -121,6 +128,7 @@ const CONFIGS: Record<EnvName, Config> = {
     api: {
       baseUrl: 'https://demo.thefittingroom.xyz/api',
       vtoTimeoutMs: 120000,
+      vtoPrefetchDelayMs: 3000,
     },
     asset: {
       baseUrl: 'http://demo.thefittingroom.xyz/s3/tfr-assets-dev/shop-sdk/assets/v5',
@@ -129,7 +137,7 @@ const CONFIGS: Record<EnvName, Config> = {
       baseUrl: 'http://demo.thefittingroom.xyz/s3/tfr-assets-dev',
     },
     features: {
-      vtoPrefetch: false,
+      vtoPrefetch: true,
     },
     ...SHARED_CONFIG,
   },


### PR DESCRIPTION
## Summary

Re-enables the `vtoPrefetch` feature flag and makes the prefetch delay configurable, plus cancels stale prefetch timers when the user changes garment selection.

- **`config.api.vtoPrefetchDelayMs`** (new, `3000`) — the delay floor before speculative non-priority VTO requests fire, measured from the most recent priority request. Replaces the hardcoded `500ms` constants in both VTO overlays (`use-vto-requests.ts` `NON_PRIORITY_REQUEST_DELAY_MS`, `vto-single.tsx` `NON_PRIORITY_VTO_REQUEST_DELAY_MS`). `0` fires immediately.
- **`config.features.vtoPrefetch`** flipped `false → true` in `development`, `production`, and `local`.
- **Stale-timer cancellation** — the multi-garment overlay now tracks queued prefetch `setTimeout` handles. A new priority request (selection change) clears them so alternates for the previous outfit never go out. Pending timers are also torn down on overlay unmount.

## Notes

- In-flight dedup is unchanged and still guarantees no duplicate in-flight POSTs: component-level `requestedKeysRef` backed by the api-layer `inFlightVtoRequests` map. A size change onto an already-in-flight prefetch reuses that request rather than firing a second one.
- `vto-single.tsx` (single-garment) gets the configurable delay but no timer-cancellation — it has no prefetch-invalidation need.

## Verification

`npm run check` and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)