### PR TITLE
Unify VTO request flow: vto-single onto the shared useVtoRequests hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,13 +134,18 @@ sorted by `(colorway_size_asset_id, untucked)` — the same ordering the backend
 hashes into the token. This is the SDK's guarantee against duplicate in-flight
 VTO requests, and it holds across both overlays since both call `requestVto`.
 
-`vto-single.tsx` keeps `framesByKey: Record<compositionKey, string[]>` for
-results and a `requestedKeysRef` Set for component-level dedup.
-`compositionKey(csaId, untucked)` is the key — untucked is always `false` for
-single-garment. The multi-garment overlay uses the `useVtoRequests` hook
-(`fitting-room/use-vto-requests.ts`), keyed by `outfitKey`. `useCache` on
-`execApiRequest` stays **off** for this endpoint; the in-flight dedup above
-plus the backend's content-hash cache cover repeat requests.
+Both VTO overlays drive that endpoint through the shared `useVtoRequests`
+hook (`src/components/overlays/use-vto-requests.ts`). The hook keys results
+and component-level dedup by `outfitKey` (items joined on
+`colorway_size_asset_id:untucked`), stores rendered frame paths per outfit,
+applies the config-driven prefetch throttle (`config.api.vtoPrefetchDelayMs`),
+and cancels still-queued prefetch timers when a new priority request fires.
+The fitting room passes multi-garment outfits plus prefetch alternates;
+`vto-single.tsx` passes a one-item outfit per size/color (`untucked` always
+`false`) — it holds no `framesByKey`/`requestedKeysRef`/`compositionKey` of
+its own. `useCache` on `execApiRequest` stays **off** for this endpoint; the
+in-flight dedup above plus the backend's content-hash cache cover repeat
+requests.
 
 ## Conventions
 

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -18,7 +18,7 @@ import { DesktopLayout } from './desktop-layout'
 import { DetailMode } from './detail-accordion-item'
 import { MobileLayout, MobileMode } from './mobile-layout'
 import { findCsaByLabel, findRecommendedColorSize, buildVtoProductDataFromResolved } from './product-data'
-import { useVtoRequests } from './use-vto-requests'
+import { useVtoRequests } from '../use-vto-requests'
 
 // Map our local OutfitItem shape (which carries the externalId for UI bookkeeping)
 // to the wire shape expected by the VTO API.

--- a/src/components/overlays/use-vto-requests.ts
+++ b/src/components/overlays/use-vto-requests.ts
@@ -4,7 +4,7 @@ import { getLogger } from '@/lib/logger'
 import { getStaticData } from '@/lib/store'
 import { applyFrameBaseUrl } from '@/lib/util'
 
-const logger = getLogger('overlays/fitting-room/use-vto-requests')
+const logger = getLogger('overlays/use-vto-requests')
 
 // outfitKey is the dedup / lookup key for a composition. Sorted to normalize
 // item ordering so two outfits with identical (csa, untucked) tuples in
@@ -31,10 +31,12 @@ export interface UseVtoRequestsHandle {
   clearError: () => void
 }
 
-// useVtoRequests encapsulates the multi-garment VTO request flow against the
-// synchronous /v1/vto-compositions endpoint: dedup POSTs by outfitKey and
-// store the rendered frame paths per outfit. The endpoint returns frames
-// directly in the response — there is no Firestore subscription.
+// useVtoRequests encapsulates the VTO request flow against the synchronous
+// /v1/vto-compositions endpoint: dedup POSTs by outfitKey and store the
+// rendered frame paths per outfit. The endpoint returns frames directly in
+// the response — there is no Firestore subscription. Shared by both VTO
+// overlays: the fitting room (multi-garment outfits + prefetch alternates)
+// and vto-single (a one-item outfit per size/color).
 export function useVtoRequests(): UseVtoRequestsHandle {
   // outfitKey → rendered frame paths
   const [framesByKey, setFramesByKey] = useState<Record<string, string[]>>({})

--- a/src/components/overlays/vto-single.tsx
+++ b/src/components/overlays/vto-single.tsx
@@ -12,9 +12,6 @@ import { VtoProductData, VtoSizeColorData, VtoSizeData } from '@/components/prod
 import { SizeSelector } from '@/components/size-selector'
 import { Text, TextT } from '@/components/text'
 import {
-  requestVto as apiRequestVto,
-} from '@/lib/api'
-import {
   AVATAR_BOTTOM_BACKGROUND_URL,
   CloseIcon,
   DragHandleIcon,
@@ -27,9 +24,10 @@ import { getLogger } from '@/lib/logger'
 import { loadProductDataToStore } from '@/lib/product'
 import { getStaticData, useMainStore } from '@/lib/store'
 import { getThemeData, useCss, CssProp, StyleProp } from '@/lib/theme'
-import { applyFrameBaseUrl, getSizeLabelFromSize } from '@/lib/util'
+import { getSizeLabelFromSize } from '@/lib/util'
 import { useMobileSheetSnap } from '@/lib/use-mobile-sheet-snap'
 import { DeviceLayout, OverlayName } from '@/lib/view'
+import { useVtoRequests } from './use-vto-requests'
 
 interface ElementSize {
   width: number
@@ -41,14 +39,6 @@ const AVATAR_GUTTER_HEIGHT_PX = 100
 const CONTENT_AREA_WIDTH_PX = 550
 
 const logger = getLogger('overlays/vto-single')
-
-// compositionKey identifies a unique 1-garment composition for in-component
-// dedup (csaId + untucked). Untucked is always false for single-garment VTO
-// (the default tucked-in state is fine for a top rendered alone); the shape
-// is kept untuck-aware for forward compatibility with multi-garment.
-function compositionKey(csaId: number, untucked: boolean): string {
-  return `${csaId}:${untucked ? 1 : 0}`
-}
 
 export default function VtoSingleOverlay() {
   const userIsLoggedIn = useMainStore((state) => state.userIsLoggedIn)
@@ -62,12 +52,9 @@ export default function VtoSingleOverlay() {
   const [selectedSizeLabel, setSelectedSizeLabel] = useState<string | null>(null)
   const [selectedColorLabel, setSelectedColorLabel] = useState<string | null>(null)
   const [modalStyle, setModalStyle] = useState<StyleProp>({})
-  // compositionKey → rendered frame paths returned by POST /v1/vto-compositions.
-  const [framesByKey, setFramesByKey] = useState<Record<string, string[]>>({})
-  // compositionKeys already requested (in-flight or completed) — dedup so a
-  // re-render doesn't re-POST the same composition.
-  const requestedKeysRef = useRef<Set<string>>(new Set())
-  const lastPriorityVtoRequestTimeRef = useRef<number | null>(null)
+  // Shared VTO request flow: dedup, prefetch throttle, and frame storage.
+  // Single-garment compositions are just one-item outfits (untucked: false).
+  const { request: vtoRequest, framesForOutfit } = useVtoRequests()
 
   // Redirect if not logged in or no avatar
   useEffect(() => {
@@ -234,55 +221,15 @@ export default function VtoSingleOverlay() {
     return { sizeColorRecord, availableColorLabels }
   }, [vtoProductData, selectedSizeLabel, selectedColorLabel])
 
-  // Fetch VTO data for a color/size. Posts a 1-item composition request to
-  // the synchronous endpoint, which returns the rendered frame paths
-  // directly; the frames are stored by compositionKey.
-  const requestVto = useCallback((sizeColorRecord: VtoSizeColorData, priority: boolean) => {
-    const csaId = sizeColorRecord.colorwaySizeAssetId
-    const key = compositionKey(csaId, false)
-    if (requestedKeysRef.current.has(key)) {
-      return
-    }
-    function executeRequest() {
-      logger.timerStart(`requestVto_${sizeColorRecord.sku}`)
-      logger.logDebug(`{{ts}} - Requesting VTO for sku: ${sizeColorRecord.sku}`, { priority, sizeColorRecord })
-      // Mark requested before the POST resolves to dedupe re-entrant calls.
-      requestedKeysRef.current.add(key)
-
-      apiRequestVto([{ colorway_size_asset_id: csaId, untucked: false }])
-        .then((resp) => {
-          logger.timerEnd(`requestVto_${sizeColorRecord.sku}`)
-          logger.logTimer(`requestVto_${sizeColorRecord.sku}`, `{{ts}} - VTO data is loaded for sku: ${sizeColorRecord.sku}`)
-          setFramesByKey((prev) => ({ ...prev, [key]: resp.frames }))
-        })
-        .catch((error) => {
-          logger.logError(`Error requesting VTO for sku: ${sizeColorRecord.sku}`, { error, sizeColorRecord })
-          // Drop the key so a later re-selection retries the render.
-          requestedKeysRef.current.delete(key)
-        })
-    }
-    // Throttle non-priority (prefetch) requests behind the most-recent
-    // priority one. The delay floor is config-driven
-    // (config.api.vtoPrefetchDelayMs); 0 fires immediately.
-    let delay: number = 0
-    if (priority) {
-      lastPriorityVtoRequestTimeRef.current = Date.now()
-    } else {
-      const lastPriorityTime = lastPriorityVtoRequestTimeRef.current
-      if (lastPriorityTime) {
-        const now = Date.now()
-        const minNextRequestTime = lastPriorityTime + getStaticData().config.api.vtoPrefetchDelayMs
-        if (now < minNextRequestTime) {
-          delay = minNextRequestTime - now
-        }
-      }
-    }
-    if (delay) {
-      setTimeout(executeRequest, delay)
-      return
-    }
-    executeRequest()
-  }, [])
+  // Request VTO for a color/size as a one-item outfit. Dedup, the prefetch
+  // throttle, and frame storage all live in the shared useVtoRequests hook;
+  // single-garment compositions are never untucked.
+  const requestVto = useCallback(
+    (sizeColorRecord: VtoSizeColorData, priority: boolean) => {
+      vtoRequest([{ colorway_size_asset_id: sizeColorRecord.colorwaySizeAssetId, untucked: false }], priority)
+    },
+    [vtoRequest],
+  )
 
   // Trigger priority VTO request when size/color selection changes
   useEffect(() => {
@@ -309,27 +256,26 @@ export default function VtoSingleOverlay() {
     }
   }, [requestVto, vtoProductData, selectedColorLabel])
 
-  // Frame URLs for the currently-selected color/size: look up the rendered
-  // frames by compositionKey, rewrite the bare paths to the configured
-  // frames base URL, and preload the resulting images.
+  // Frame URLs for the currently-selected color/size: ask the shared hook
+  // for this one-item outfit's rendered frames (already base-URL-rewritten),
+  // then preload the images.
   const frameUrls = useMemo(() => {
     if (!selectedColorSizeRecord) {
       return null
     }
-    const key = compositionKey(selectedColorSizeRecord.colorwaySizeAssetId, false)
-    const frames = framesByKey[key]
-    if (!frames || frames.length === 0) {
+    const rewritten = framesForOutfit([
+      { colorway_size_asset_id: selectedColorSizeRecord.colorwaySizeAssetId, untucked: false },
+    ])
+    if (!rewritten) {
       return null
     }
     logger.logDebug(`{{ts}} - Displaying VTO for sku: ${selectedColorSizeRecord.sku}`)
-    const baseUrl = getStaticData().config.frames.baseUrl
-    const rewritten = frames.map((u) => applyFrameBaseUrl(u, baseUrl))
     rewritten.forEach((url) => {
       const img = new Image()
       img.src = url
     })
     return rewritten
-  }, [selectedColorSizeRecord, framesByKey])
+  }, [selectedColorSizeRecord, framesForOutfit])
 
   const handleSignOutClick = useCallback(() => {
     closeOverlay()


### PR DESCRIPTION
## Summary

`vto-single.tsx` carried its own duplicate of the VTO request mechanics — `requestedKeysRef` dedup, `framesByKey` storage, the prefetch throttle, and a `compositionKey` helper — structurally identical to the `useVtoRequests` hook the multi-garment fitting room already uses. A single garment is just a one-item outfit, so the hook fully subsumes it. This removes the duplication.

- **Move** `use-vto-requests.ts` from `overlays/fitting-room/` to `overlays/` — it's now genuinely shared by both VTO overlays.
- **`vto-single.tsx`**: drop `compositionKey`, `framesByKey`, `requestedKeysRef`, `lastPriorityVtoRequestTimeRef`, and the hand-rolled `requestVto`; delegate to `useVtoRequests`. `requestVto` becomes a thin adapter wrapping each size/color as a one-item outfit (`untucked` always `false`). Image preloading and the sku debug log are kept at the call site.
- Update the fitting-room import path and `AGENTS.md`'s VTO request flow section.

## Behavior

Unchanged. `outfitKey([{csa, untucked:false}])` and the old `compositionKey(csa, false)` produce the same string, so dedup/lookup keys are byte-identical. vto-single now also gets prefetch-timer cancellation and unmount teardown for free.

The hook's `lastError` is exposed but **not yet surfaced** in vto-single's UI — vto-single has no error snackbar, and adding one is out of scope here. Errors are still logged (same observable behavior as before). Wiring an error toast into vto-single is a possible follow-up.

Net: −89 / +42 lines.

## Verification

`npm run check` + `npm run build` pass. Exercised end-to-end against the local stack with `?tfr-source=local`:

- Single-garment VTO renders — priority request for the recommended size, avatar frames display.
- Prefetch fires for the non-selected sizes (`vtoPrefetch` on).
- Switching to a prefetched size reuses the cached composition — **no duplicate POST** (verified in the network panel: 3 POSTs total for 3 sizes, none on re-selection).
- No SDK console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)