### PR TITLE
Add demo environment; restore local to the localhost Docker stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,13 @@ or insert a step without tracing the deps.
 
 ## Environment selection
 
-`InitParams.environment` is an `EnvName` (`development` | `production` | `local`).
-`src/lib/config.ts` maps each to firebase/api/asset/frames URLs. `local` points at
-the `local-deployment` Docker stack (`http://localhost:8080`, MinIO at `:9000`) and
-reuses the dev Firebase project.
+`InitParams.environment` is an `EnvName` (`development` | `production` | `demo`
+| `local`). `src/lib/config.ts` maps each to firebase/api/asset/frames URLs.
+`demo` points at the hosted demo server (`demo.thefittingroom.xyz`); `local`
+points at the `local-deployment` Docker stack on the developer's host
+(`http://localhost:8080`, s3proxy at `:9000`). Both reuse the dev Firebase
+project. The Shopify theme defaults to `demo` and switches to `local` when the
+page URL carries `?tfr-source=local`.
 
 ## Frame URL rewriting
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -47,6 +47,9 @@ export interface Config {
 export enum EnvName {
   DEVELOPMENT = 'development',
   PRODUCTION = 'production',
+  // Hosted demo server (demo.thefittingroom.xyz).
+  DEMO = 'demo',
+  // The local-deployment Docker stack running on the developer's host.
   LOCAL = 'local',
 }
 
@@ -115,7 +118,7 @@ const CONFIGS: Record<EnvName, Config> = {
     },
     ...SHARED_CONFIG,
   },
-  [EnvName.LOCAL]: {
+  [EnvName.DEMO]: {
     firebase: {
       apiKey: 'AIzaSyDfjBWzpmzb-mhGN8VSURxzLg6nkzmKUD8',
       authDomain: 'fittingroom-dev-5d248.firebaseapp.com',
@@ -135,6 +138,32 @@ const CONFIGS: Record<EnvName, Config> = {
     },
     frames: {
       baseUrl: 'http://demo.thefittingroom.xyz/s3/tfr-assets-dev',
+    },
+    features: {
+      vtoPrefetch: true,
+    },
+    ...SHARED_CONFIG,
+  },
+  [EnvName.LOCAL]: {
+    firebase: {
+      apiKey: 'AIzaSyDfjBWzpmzb-mhGN8VSURxzLg6nkzmKUD8',
+      authDomain: 'fittingroom-dev-5d248.firebaseapp.com',
+      projectId: 'fittingroom-dev-5d248',
+      storageBucket: 'fittingroom-dev-5d248.appspot.com',
+      messagingSenderId: '2298664147',
+      appId: '1:2298664147:web:340bda75cd5d25f3997026',
+      measurementId: 'G-B7GDQ1Y9LL',
+    },
+    api: {
+      baseUrl: 'http://localhost:8080',
+      vtoTimeoutMs: 120000,
+      vtoPrefetchDelayMs: 3000,
+    },
+    asset: {
+      baseUrl: 'http://localhost:9000/tfr-assets-dev/shop-sdk/assets/v5',
+    },
+    frames: {
+      baseUrl: 'http://localhost:9000/tfr-assets-dev',
     },
     features: {
       vtoPrefetch: true,


### PR DESCRIPTION
## Summary

The `local` environment config had been hijacked to point at the hosted demo server (`demo.thefittingroom.xyz`), leaving no environment that actually targets the `local-deployment` Docker stack. This separates the two.

- **New `EnvName.DEMO`** — holds what `local` was pointing at (`demo.thefittingroom.xyz` api/asset/frames).
- **`EnvName.LOCAL` restored** to the localhost Docker stack — api on `:8080`, asset/frames on the s3proxy at `:9000` (the values from before the hijack).

Both environments keep the dev Firebase project and the same feature flags (`vtoPrefetch: true`, `vtoPrefetchDelayMs: 3000`).

## Companion change

The Shopify theme will default `environment` to `demo` and override to `local` when the page URL carries `?tfr-source=local`. That's a separate change in the theme repo.

**Ordering:** this SDK change must be released (published to npm, so `unpkg.com/@thefittingroom/shop-ui@5` serves it) **before** the theme is switched to `environment: 'demo'` — otherwise the live demo storefront would call `getConfig('demo')` on an SDK build that doesn't know the value and throw `Invalid environment "demo"`.

## Verification

`npm run check` + `npm run build` pass. `index.tsx` validates `environment` against `Object.values(EnvName)`, so `'demo'` is now accepted. AGENTS.md "Environment selection" updated (also corrects a stale "MinIO" reference — the local stack uses s3proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)