### PR TITLE
Overlay typography (Inter) + PDP Try-It-On preselects current product

### DIFF
--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ButtonT } from '@/components/button'
 import { Loading } from '@/components/content/loading'
 import { LinkT } from '@/components/link'
@@ -52,7 +52,13 @@ function measureTopOffset(): number {
   }
 }
 
-export default function FittingRoomOverlay() {
+export interface FittingRoomOverlayProps {
+  // externalId of a product to preselect on open — set when the overlay is
+  // opened from the PDP "Try It On" CTA so the viewed product joins the outfit.
+  preselectExternalId?: string
+}
+
+export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomOverlayProps) {
   const deviceLayout = useMainStore((state) => state.deviceLayout)
   const userIsLoggedIn = useMainStore((state) => state.userIsLoggedIn)
   const userHasAvatar = useMainStore((state) => state.userHasAvatar)
@@ -300,6 +306,22 @@ export default function FittingRoomOverlay() {
       setOpenAccordionItemId(null)
     }
   }, [openAccordionItemId, selectedExternalIds])
+
+  // Preselect the current PDP product when the overlay was opened from the
+  // "Try It On" CTA. The CTA adds the product to the fitting room asynchronously,
+  // so wait until it resolves into `resolved.items`, then run the normal
+  // selection path (auto-size-rec, accordion open) exactly once.
+  const preselectAppliedRef = useRef(false)
+  useEffect(() => {
+    if (preselectAppliedRef.current || !preselectExternalId) {
+      return
+    }
+    if (!resolved.items.some((i) => i.externalId === preselectExternalId)) {
+      return
+    }
+    preselectAppliedRef.current = true
+    handleSelectItem(preselectExternalId)
+  }, [preselectExternalId, resolved.items, handleSelectItem])
 
   // Derive the current outfit. Memoized so identity is stable when nothing
   // material changed (avoids re-firing the request effect on every render).

--- a/src/components/text.tsx
+++ b/src/components/text.tsx
@@ -14,7 +14,7 @@ export const Text = forwardRef<HTMLSpanElement, TextProps>(({ children, variant,
   const variantCss = useVariantCss<TextVariant>(variant, (theme) => ({
     base: {
       color: theme.color_fg_text,
-      fontFamily: 'sans-serif',
+      fontFamily: theme.font_family,
       fontSize: '14px',
     },
     brand: {
@@ -24,6 +24,7 @@ export const Text = forwardRef<HTMLSpanElement, TextProps>(({ children, variant,
     },
     error: {
       color: theme.color_danger,
+      fontFamily: theme.font_family,
       fontSize: '14px',
     },
   }))

--- a/src/components/widgets/vto-button.tsx
+++ b/src/components/widgets/vto-button.tsx
@@ -1,5 +1,6 @@
 import { TextT } from '@/components/text'
 import { TfrIcon } from '@/lib/asset'
+import { ensureFittingRoomItem } from '@/lib/fitting-room-storage'
 import { getLogger } from '@/lib/logger'
 import { getStaticData, useMainStore } from '@/lib/store'
 import { useCss } from '@/lib/theme'
@@ -13,7 +14,8 @@ const logger = getLogger('widgets/vto-button')
 // otherwise it opens the single-garment quick-view ("Quick View Try On").
 export default function VtoButtonWidget(_props: WidgetProps) {
   const openOverlay = useMainStore((state) => state.openOverlay)
-  const currentProductId = getStaticData().currentProduct?.externalId ?? null
+  const currentProduct = getStaticData().currentProduct ?? null
+  const currentProductId = currentProduct?.externalId ?? null
   // "Other" items = fitting-room entries that aren't the current product.
   const hasOtherFittingRoomItems = useMainStore((state) =>
     state.fittingRoom.some((item) => item.externalId !== currentProductId),
@@ -47,13 +49,23 @@ export default function VtoButtonWidget(_props: WidgetProps) {
   }))
 
   const handleClick = () => {
-    if (hasOtherFittingRoomItems) {
-      logger.logDebug('{{ts}} - Opening fitting-room overlay')
-      openOverlay(OverlayName.FITTING_ROOM)
-    } else {
+    if (!hasOtherFittingRoomItems) {
       logger.logDebug('{{ts}} - Opening quick-view overlay')
       openOverlay(OverlayName.QUICK_VIEW)
+      return
     }
+    logger.logDebug('{{ts}} - Opening fitting-room overlay')
+    if (!currentProductId) {
+      openOverlay(OverlayName.FITTING_ROOM)
+      return
+    }
+    // Make sure the product the shopper is viewing is in the fitting room so
+    // the overlay can preselect it. The add is async (it resolves the chosen
+    // size/colour); the overlay's preselect effect waits for it to land.
+    ensureFittingRoomItem(currentProductId, currentProduct?.handle ?? null, true).catch((error) => {
+      logger.logError('Failed to add current product to fitting room', { error })
+    })
+    openOverlay(OverlayName.FITTING_ROOM, { preselectExternalId: currentProductId })
   }
 
   return (

--- a/src/lib/fitting-room-storage.ts
+++ b/src/lib/fitting-room-storage.ts
@@ -60,14 +60,9 @@ export function _init(): void {
   useMainStore.setState({ fittingRoom: items })
 }
 
-export async function toggleFittingRoomItem(productId: string, handle: string | null, isPdp: boolean): Promise<void> {
+// The add path shared by toggleFittingRoomItem and ensureFittingRoomItem.
+async function addFittingRoomItem(productId: string, handle: string | null, isPdp: boolean): Promise<void> {
   const state = useMainStore.getState()
-  const isInFittingRoom = state.fittingRoom.some((item) => item.externalId === productId)
-  if (isInFittingRoom) {
-    logger.logDebug('{{ts}} - Removing from fitting room', { productId })
-    state.removeFromFittingRoom(productId)
-    return
-  }
   logger.logDebug('{{ts}} - Adding to fitting room', { productId, handle, isPdp })
 
   let size: string | null = null
@@ -113,4 +108,30 @@ export async function toggleFittingRoomItem(productId: string, handle: string | 
     colorwaySizeAssetId,
     addedAt: Date.now(),
   })
+}
+
+export async function toggleFittingRoomItem(productId: string, handle: string | null, isPdp: boolean): Promise<void> {
+  const state = useMainStore.getState()
+  const isInFittingRoom = state.fittingRoom.some((item) => item.externalId === productId)
+  if (isInFittingRoom) {
+    logger.logDebug('{{ts}} - Removing from fitting room', { productId })
+    state.removeFromFittingRoom(productId)
+    return
+  }
+  await addFittingRoomItem(productId, handle, isPdp)
+}
+
+// Add the product to the fitting room if it isn't already there — never
+// removes. Used when opening the fitting-room overlay from the PDP "Try It
+// On" CTA, where the current product must be present so it can be preselected.
+export async function ensureFittingRoomItem(
+  productId: string,
+  handle: string | null,
+  isPdp: boolean,
+): Promise<void> {
+  const state = useMainStore.getState()
+  if (state.fittingRoom.some((item) => item.externalId === productId)) {
+    return
+  }
+  await addFittingRoomItem(productId, handle, isPdp)
 }

--- a/src/lib/fitting-room-storage.ts
+++ b/src/lib/fitting-room-storage.ts
@@ -124,11 +124,7 @@ export async function toggleFittingRoomItem(productId: string, handle: string | 
 // Add the product to the fitting room if it isn't already there — never
 // removes. Used when opening the fitting-room overlay from the PDP "Try It
 // On" CTA, where the current product must be present so it can be preselected.
-export async function ensureFittingRoomItem(
-  productId: string,
-  handle: string | null,
-  isPdp: boolean,
-): Promise<void> {
+export async function ensureFittingRoomItem(productId: string, handle: string | null, isPdp: boolean): Promise<void> {
   const state = useMainStore.getState()
   if (state.fittingRoom.some((item) => item.externalId === productId)) {
     return

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -14,14 +14,14 @@ export interface ThemeData {
   font_family: string
 }
 export const themeData: ThemeData = {
-  brand_font_family: 'TN web use only, Times New Roman, serif',
+  brand_font_family: "'Inter', sans-serif",
   brand_link_text_decoration: 'underline',
   brand_button_background_color: '#FFA273',
   brand_button_text_color: '#21201F',
   color_danger: '#900B09',
   color_fg_text: '#21201F',
   color_tfr_800: '#265A64',
-  font_family: 'sans-serif',
+  font_family: "'Inter', sans-serif",
 }
 
 export function _init(initThemeData: Partial<ThemeData> | null) {

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
+/* Inter — the SDK's own typeface, matching the Figma designs. Loaded here so
+   overlay text renders in Inter regardless of the host page's fonts. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 body.tfr-modal-open {
   overflow: hidden;
   position: fixed;


### PR DESCRIPTION
Two unrelated overlay changes shipped together.

## Typography — load Inter, drop the serif

Overlays were rendering brand text (titles, product names, headings) in
**Times New Roman**. Cause: the default `brand_font_family` token was
`'TN web use only, Times New Roman, serif'`, and "TN web use only" is
never loaded — so it fell through to the serif fallback. The Figma designs
use **Inter** throughout.

- `src/style.css` — `@import` Inter (weights 400/500/600/700) from Google
  Fonts at the top of the injected stylesheet so it loads in the host page
  regardless of merchant theme.
- `src/lib/theme.ts` — both `brand_font_family` and `font_family` defaults
  now `"'Inter', sans-serif"`.
- `src/components/text.tsx` — `base` variant reads `theme.font_family`
  (was a hardcoded `'sans-serif'` literal); `error` variant gets a
  `fontFamily` so it stops inheriting the host page's font.

Every `fontFamily` reference in the SDK already routes through these two
theme tokens (`button`, `link`, `quick-view`, `product-card`, `text`), so
this single swap covers all overlay text — no per-component edits needed.

## PDP "Try It On" — preselect the current product

The PDP `vto-button` widget routes to the fitting-room overlay when the
shopper has other items waiting. Bug: the overlay opened without
including the product the shopper was actually viewing.

- `src/lib/fitting-room-storage.ts` — extract the add path into a shared
  `addFittingRoomItem`; add `ensureFittingRoomItem(productId, handle,
  isPdp)`: idempotent, adds if missing, never removes (unlike
  `toggleFittingRoomItem`).
- `src/components/widgets/vto-button.tsx` — on the fitting-room branch,
  call `ensureFittingRoomItem` for the current product and open with
  `{ preselectExternalId: currentProductId }`.
- `src/components/overlays/fitting-room/index.tsx` — accept
  `preselectExternalId`; a once-only effect waits for the product to
  resolve into `resolved.items` (the add is async — it resolves
  size/colour from the PDP), then runs the normal `handleSelectItem`
  path. The preselected product gets auto-size-rec and (on desktop)
  opens its accordion exactly as if the shopper tapped its card.

Edge cases:
- If PDP has a size selected, that size's `colorwaySizeAssetId` is
  resolved at add time; otherwise auto-size-rec picks the recommended size.
- If the product is already in the fitting room, `ensureFittingRoomItem`
  no-ops and preselection still works.
- On mobile the product is added to the selection but stays in browse mode
  — the shopper still taps "TRY IT ON" to enter the try-on view, matching
  existing selection design.

## Verification

- `npm run check` (tsc + ESLint + prettier) clean — 0 errors, 13 pre-existing
  `exhaustive-deps` warnings.
- `npm run build` produces `dist/index.js`; verified the Google Fonts
  `@import` URL is preserved in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)