### PR TITLE
e2e test framework — Playwright + mocked Firebase via InitParams.testHooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,17 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ node_modules/
 go.mod
 go.sum
 firebase-service-account/*
+
+playwright-report/
+test-results/
+tests/e2e/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,33 @@ populates it (from `InitParams` or the store), and accessor functions. Order
 matters — each `_init` may rely on an earlier one having run, so do not reorder
 or insert a step without tracing the deps.
 
+## Testing
+
+E2E tests live in `tests/e2e/` and run via Playwright (Chromium). The harness
+builds the bundle, serves the repo with `npm run serve`, and loads
+`tests/e2e/fixtures/host.html` — a minimal Shopify-free analog of
+`local-repo/shopify/assets/tfr.js`. Run them with `npm run test:e2e` (or
+`npm run test:e2e:ui` to debug interactively).
+
+**Firebase is mocked, not emulated.** `src/lib/firebase-mock.ts` provides
+`MockAuthManager` and `MockFirestoreManager` that satisfy the `IAuthManager` /
+`IFirestoreManager` interfaces. They're activated via `InitParams.testHooks`
+— a data-only test hatch. The branch lives in exactly one place, at the top
+of `_init` in `src/lib/firebase.ts`; no other file in `src/` knows about test
+mode, and no `window.X` lookup happens in the SDK itself (the test host
+fixture reads `window.__TFR_TEST_CONFIG__` and threads it into `init`).
+
+Production callers MUST NOT set `InitParams.testHooks`. The field is
+namespaced and documented as test-only.
+
+REST endpoints (`/v1/styles/{id}/recommendation`, `/v1/style-categories`,
+`/v1/style-category-groups`, `/v1/vto-compositions`) are mocked via Playwright
+`page.route()` from `tests/e2e/mocks/api.ts`. Per-test overrides drive error
+paths and edge cases.
+
+`npm run check` stays cheap (tsc + ESLint + Prettier). `npm run test` runs the
+e2e suite. CI runs both — see `.github/workflows/build.yml`.
+
 ## Environment selection
 
 `InitParams.environment` is an `EnvName` (`development` | `production` | `demo`
@@ -196,8 +223,14 @@ gen / Firestore-conventions notes above are easy to drift from when
 files move or shapes change — keep AGENTS.md edits in the same change as
 the code they describe.
 
-- [ ] `npm run check` (tsc --noEmit + ESLint) clean
+- [ ] `npm run check` (tsc --noEmit + ESLint + Prettier) clean
 - [ ] `npm run build` produces `dist/index.js` without errors
+- [ ] `npm run test:e2e` passes (locally or in CI)
+- [ ] If the change touches Firebase, the REST API, the `_init` sequence, or
+      the `InitParams` shape: e2e fixtures (`tests/e2e/fixtures/host.html`,
+      `tests/e2e/fixtures/seed.ts`, `tests/e2e/mocks/api.ts`) still match the
+      contract, and `MockAuthManager` / `MockFirestoreManager` still satisfy
+      `IAuthManager` / `IFirestoreManager`
 - [ ] If consumed any new or changed backend types: `npm run gen-types`
       ran and the `src/api/gen/*` diff is committed in the same change
 - [ ] If a new `_init` step was added: placed correctly in the `init`

--- a/README.md
+++ b/README.md
@@ -18,12 +18,29 @@ npm ci
 | Script | What it does |
 |---|---|
 | `npm run build` | Clean + production build into `dist/` |
-| `npm run check` | Type-check (`tsc --noEmit`) |
+| `npm run check` | Type-check (`tsc --noEmit`) + ESLint + Prettier |
 | `npm run watch` | Vite build in watch mode |
 | `npm run serve` | Static-serve the repo on `:5173` with CORS |
 | `npm run watch-serve` | Both `watch` and `serve` together; Ctrl+C stops both |
+| `npm run test` / `npm run test:e2e` | Playwright e2e suite (Chromium) against the built bundle |
+| `npm run test:e2e:ui` | Playwright UI runner for local debugging |
 | `npm run gen-types` | Regenerate `src/api/gen/*.ts` from `tfr-backend` Go types |
 | `npm run promote-latest [version]` | Move npm dist-tag `latest` onto a published version (defaults to current `package.json` version) |
+
+## Running e2e tests
+
+First-time setup: `npm install && npx playwright install chromium` (the
+second command downloads the Chromium binary once; cached afterwards). Then
+`npm run test:e2e` runs the suite. Specs live under `tests/e2e/`; they boot
+the built bundle in headless Chromium against a static fixture page
+(`tests/e2e/fixtures/host.html`) that mimics the minimal contract the Shopify
+theme provides. Firebase is mocked via `InitParams.testHooks`
+(see `src/lib/firebase-mock.ts`); REST endpoints are mocked via
+`page.route()`. See AGENTS.md for the architecture and constraints.
+
+For an interactive debug loop, `npm run watch-serve &` in one terminal and
+`npm run test:e2e:ui` in another — Playwright reuses the live-rebuilt
+`:5173`.
 
 ## Release process
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,4 +77,28 @@ export default tseslint.config(
     files: ['src/**/*.{ts,tsx}'],
     rules: { curly: ['error', 'all'] },
   },
+  {
+    // Tests and Playwright config aren't part of the main tsconfig's include,
+    // so we lint them without the type-aware project service. Same style
+    // rules; the type-checking part is provided by Playwright's own runtime
+    // tsc-via-esbuild pass.
+    files: ['tests/**/*.ts', 'playwright.config.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      globals: { ...globals.node, ...globals.browser },
+    },
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      curly: ['error', 'all'],
+      'no-var': 'error',
+      'prefer-const': 'error',
+    },
+  },
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.60.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/react-modal": "^3.16.3",
@@ -1828,6 +1829,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6216,6 +6233,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,12 @@
     "promote-latest": "sh scripts/promote-latest.sh",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write src",
-    "format:check": "prettier --check src"
+    "format": "prettier --write src tests playwright.config.ts",
+    "format:check": "prettier --check src tests playwright.config.ts",
+    "test": "npm run test:e2e",
+    "test:e2e": "playwright test",
+    "test:e2e:debug": "PWDEBUG=1 playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "engines": {
     "node": ">=22"
@@ -33,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.60.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/react-modal": "^3.16.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@playwright/test'
+
+// E2E test config. The harness boots the built bundle in real Chromium against
+// a static fixture page that mimics the minimal contract the Shopify theme
+// provides (see local-repo/shopify/assets/tfr.js for the reference). Firebase
+// is mocked via InitParams.testHooks (see src/lib/firebase-mock.ts); the REST
+// API is mocked via page.route() (see tests/e2e/mocks/api.ts).
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry',
+    video: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+  webServer: {
+    // Build fresh so the suite always runs against the current src/. `serve`
+    // exposes the repo root with CORS — both /dist/index.js and the test
+    // fixtures are reachable from the same origin.
+    command: 'npm run build && npm run serve',
+    url: 'http://127.0.0.1:5173/dist/index.js',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { _init as initApi } from '@/lib/api'
 import { _init as initAsset } from '@/lib/asset'
 import { getConfig, EnvName } from '@/lib/config'
 import { _init as initFirebase, getAuthManager } from '@/lib/firebase'
+import type { TestHooks } from '@/lib/firebase-mock'
 import { _init as initFittingRoom } from '@/lib/fitting-room-storage'
 import { i18n } from '@/lib/locale'
 import { _init as initLogger, getLogger } from '@/lib/logger'
@@ -48,6 +49,10 @@ export interface InitParams {
   productLookup?: ProductLookup
   getOverlayTopOffset?: GetOverlayTopOffset
   addToCart?: AddToCart
+  // Test-only data hatch. Production callers MUST NOT set this. When present,
+  // Firebase is replaced with in-memory mocks seeded from this object — see
+  // src/lib/firebase-mock.ts and the branch at the top of src/lib/firebase.ts.
+  testHooks?: TestHooks
 }
 
 export async function init(initParams: InitParams): Promise<boolean> {
@@ -63,6 +68,7 @@ export async function init(initParams: InitParams): Promise<boolean> {
       productLookup,
       getOverlayTopOffset,
       addToCart,
+      testHooks,
     } = initParams
 
     // Validate init params
@@ -97,6 +103,7 @@ export async function init(initParams: InitParams): Promise<boolean> {
       productLookup: productLookup ?? null,
       getOverlayTopOffset: getOverlayTopOffset ?? null,
       addToCart: addToCart ?? null,
+      testHooks,
     })
 
     // Hydrate fitting room from localStorage

--- a/src/lib/firebase-mock.ts
+++ b/src/lib/firebase-mock.ts
@@ -1,0 +1,284 @@
+// In-memory Firebase Auth + Firestore replacements driven by InitParams.testHooks.
+//
+// Activated only when the SDK is initialized with `testHooks` set. Production
+// callers MUST NOT set that field; it exists as a data hatch for the Playwright
+// e2e suite so tests can run without real Firebase credentials or emulators.
+//
+// The branch that swaps real → mock lives in exactly one place: the top of
+// `_init` in `src/lib/firebase.ts`. Nothing else in `src/` knows about test
+// mode.
+
+import type { DocumentData, QueryFieldFilterConstraint, QuerySnapshot, Unsubscribe } from 'firebase/firestore'
+import type { AuthUser, UserProfile } from '@/lib/firebase'
+import { getLogger } from '@/lib/logger'
+
+const logger = getLogger('firebase-mock')
+
+/**
+ * Test-only data hatch. Production callers MUST NOT set `InitParams.testHooks`.
+ *
+ * `auth` omitted → simulates a logged-out shopper.
+ * `auth.profile` provided → auto-seeds `firestore.docs.users[uid]` so callers
+ * only need to specify the profile once.
+ */
+export interface TestHooks {
+  auth?: {
+    uid: string
+    email: string
+    idToken: string
+    profile?: UserProfile
+  }
+  firestore?: {
+    docs?: Record<string, Record<string, Record<string, unknown>>>
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Interfaces — the public surface of the real managers. Both the real and the
+// mock classes implement these; firebase.ts's module variables type against
+// them so call sites stay unchanged regardless of which implementation is
+// installed.
+// ---------------------------------------------------------------------------
+
+export interface IFirestoreManager {
+  getDocData<T extends DocumentData = DocumentData>(collectionName: string, docId: string): Promise<T | null>
+  setDocData<T extends DocumentData = DocumentData>(collectionName: string, docId: string, data: T): Promise<void>
+  mergeDocData<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    docId: string,
+    data: Partial<T>,
+  ): Promise<void>
+  listenToDoc<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    docId: string,
+    callback: (data: T | null) => void,
+  ): Unsubscribe
+  queryDocs<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    constraints: QueryFieldFilterConstraint[],
+  ): Promise<QuerySnapshot<T>>
+}
+
+export interface IAuthManager {
+  addAuthStateChangeListener(callback: (authUser: AuthUser | null) => void): () => void
+  removeAuthStateChangeListener(callback: (authUser: AuthUser | null) => void): void
+  addUserProfileChangeListener(callback: (userProfile: UserProfile | null) => void): () => void
+  removeUserProfileChangeListener(callback: (userProfile: UserProfile | null) => void): void
+  getAuthUser(): AuthUser | null
+  getAuthToken(forceRefresh?: boolean): Promise<string>
+  getUserProfile(forceRefresh?: boolean): Promise<UserProfile | null>
+  login(email: string, password: string): Promise<AuthUser>
+  logout(): Promise<void>
+  sendPasswordResetEmail(email: string): Promise<void>
+  confirmPasswordReset(code: string, newPassword: string): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// MockFirestoreManager — in-memory document store. Reads return seeded data;
+// `listenToDoc` calls back once with the current value and returns a no-op
+// unsubscribe; writes update the in-memory map. No live-change simulation
+// (good enough for the v1 e2e suite).
+// ---------------------------------------------------------------------------
+
+type DocMap = Record<string, Record<string, DocumentData>>
+
+export class MockFirestoreManager implements IFirestoreManager {
+  private readonly docs: DocMap
+
+  constructor(seedDocs: Record<string, Record<string, Record<string, unknown>>> = {}) {
+    // Shallow-clone per collection so test mutations don't leak into the
+    // caller-owned seed object.
+    const cloned: DocMap = {}
+    for (const [coll, byId] of Object.entries(seedDocs)) {
+      cloned[coll] = { ...byId } as Record<string, DocumentData>
+    }
+    this.docs = cloned
+  }
+
+  async getDocData<T extends DocumentData = DocumentData>(collectionName: string, docId: string): Promise<T | null> {
+    const doc = this.docs[collectionName]?.[docId]
+    return (doc as T) ?? null
+  }
+
+  async setDocData<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    docId: string,
+    data: T,
+  ): Promise<void> {
+    if (!this.docs[collectionName]) {
+      this.docs[collectionName] = {}
+    }
+    this.docs[collectionName][docId] = data
+  }
+
+  async mergeDocData<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    docId: string,
+    data: Partial<T>,
+  ): Promise<void> {
+    if (!this.docs[collectionName]) {
+      this.docs[collectionName] = {}
+    }
+    const existing = this.docs[collectionName][docId] ?? {}
+    this.docs[collectionName][docId] = { ...existing, ...data }
+  }
+
+  listenToDoc<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    docId: string,
+    callback: (data: T | null) => void,
+  ): Unsubscribe {
+    // Fire once synchronously with the current value; no live updates.
+    const doc = this.docs[collectionName]?.[docId]
+    callback((doc as T) ?? null)
+    return () => {
+      /* no-op unsubscribe */
+    }
+  }
+
+  async queryDocs<T extends DocumentData = DocumentData>(
+    collectionName: string,
+    _constraints: QueryFieldFilterConstraint[],
+  ): Promise<QuerySnapshot<T>> {
+    // Ignore the constraints — return every doc in the collection. v1 tests
+    // don't exercise filtering, and the caller surface we ship (database.ts)
+    // only reads `.empty`, `.docs[].data()`, and `.forEach()`.
+    const entries = Object.values(this.docs[collectionName] ?? {})
+    const docs = entries.map((data) => ({ data: () => data as T }))
+    const snapshot = {
+      empty: docs.length === 0,
+      docs,
+      forEach: (cb: (doc: { data: () => T }) => void) => docs.forEach(cb),
+    }
+    return snapshot as unknown as QuerySnapshot<T>
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MockAuthManager — listener-on-add semantics match AuthManager line-for-line
+// (see src/lib/firebase.ts:149-167). The store wiring in src/index.tsx relies
+// on the immediate-invoke behaviour on `addAuthStateChangeListener` and
+// `addUserProfileChangeListener` to publish initial state, so the mock must
+// preserve it exactly.
+// ---------------------------------------------------------------------------
+
+interface MockAuthSeed {
+  uid: string
+  email: string
+  idToken: string
+}
+
+function makeMockAuthUser(seed: MockAuthSeed): AuthUser {
+  // The real SDK only reads `uid`, `email`, and `getIdToken()` off the User
+  // object — see firebase.ts:151,174,182,193. The cast-through-unknown keeps
+  // the surface honest about what the mock actually provides.
+  const fake = {
+    uid: seed.uid,
+    email: seed.email,
+    getIdToken: async (_forceRefresh?: boolean) => seed.idToken,
+  }
+  return fake as unknown as AuthUser
+}
+
+export class MockAuthManager implements IAuthManager {
+  private readonly seed: MockAuthSeed | null
+  private currentUser: AuthUser | null
+  private userProfile: UserProfile | null = null
+  private readonly firestore: IFirestoreManager
+  private readonly authStateChangeListeners: Set<(authUser: AuthUser | null) => void> = new Set()
+  private readonly userProfileChangeListeners: Set<(userProfile: UserProfile | null) => void> = new Set()
+  private profileUnsub: Unsubscribe | null = null
+
+  constructor(seed: MockAuthSeed | null, firestore: IFirestoreManager) {
+    this.seed = seed
+    this.currentUser = seed ? makeMockAuthUser(seed) : null
+    this.firestore = firestore
+
+    // Mirror the real AuthManager constructor: register the internal handler,
+    // which immediately invokes for the current user and sets up the profile
+    // listener BEFORE any external `addUserProfileChangeListener` arrives.
+    this.addAuthStateChangeListener((authUser) => this.handleAuthStateChanged(authUser))
+  }
+
+  addAuthStateChangeListener(callback: (authUser: AuthUser | null) => void): () => void {
+    this.authStateChangeListeners.add(callback)
+    callback(this.currentUser)
+    return () => {
+      this.authStateChangeListeners.delete(callback)
+    }
+  }
+
+  removeAuthStateChangeListener(callback: (authUser: AuthUser | null) => void): void {
+    this.authStateChangeListeners.delete(callback)
+  }
+
+  addUserProfileChangeListener(callback: (userProfile: UserProfile | null) => void): () => void {
+    this.userProfileChangeListeners.add(callback)
+    callback(this.userProfile)
+    return () => {
+      this.userProfileChangeListeners.delete(callback)
+    }
+  }
+
+  removeUserProfileChangeListener(callback: (userProfile: UserProfile | null) => void): void {
+    this.userProfileChangeListeners.delete(callback)
+  }
+
+  getAuthUser(): AuthUser | null {
+    return this.currentUser
+  }
+
+  async getAuthToken(_forceRefresh: boolean = false): Promise<string> {
+    if (!this.currentUser || !this.seed) {
+      throw new Error('No authenticated user')
+    }
+    return this.seed.idToken
+  }
+
+  async getUserProfile(_forceRefresh: boolean = false): Promise<UserProfile | null> {
+    return this.userProfile
+  }
+
+  async login(_email: string, _password: string): Promise<AuthUser> {
+    throw new Error('MockAuthManager.login is not supported — seed the user via InitParams.testHooks.auth')
+  }
+
+  async logout(): Promise<void> {
+    if (this.profileUnsub) {
+      this.profileUnsub()
+      this.profileUnsub = null
+    }
+    this.currentUser = null
+    this.userProfile = null
+    this.authStateChangeListeners.forEach((cb) => cb(null))
+    this.userProfileChangeListeners.forEach((cb) => cb(null))
+  }
+
+  async sendPasswordResetEmail(_email: string): Promise<void> {
+    // No-op: tests that need to assert "email sent" should spy on this method
+    // via the network mock layer if/when needed.
+  }
+
+  async confirmPasswordReset(_code: string, _newPassword: string): Promise<void> {
+    // No-op for parity with sendPasswordResetEmail.
+  }
+
+  private handleAuthStateChanged(authUser: AuthUser | null) {
+    if (this.profileUnsub) {
+      this.profileUnsub()
+      this.profileUnsub = null
+    }
+    if (authUser) {
+      logger.logDebug('Mock user logged in:', { uid: authUser.uid })
+      this.profileUnsub = this.firestore.listenToDoc<UserProfile>('users', authUser.uid, (profile) => {
+        this.userProfile = profile
+        this.userProfileChangeListeners.forEach((cb) => cb(this.userProfile))
+      })
+      // Intentionally skip the user_logging write — tests don't exercise login
+      // throttling and a tolerant no-op keeps fixtures simpler.
+    } else {
+      this.userProfile = null
+      this.userProfileChangeListeners.forEach((cb) => cb(null))
+    }
+  }
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -19,6 +19,8 @@ import {
   signInWithEmailAndPassword,
 } from 'firebase/auth'
 import type { FirestoreUser } from '@/api/gen/responses'
+import type { IAuthManager, IFirestoreManager } from '@/lib/firebase-mock'
+import { MockAuthManager, MockFirestoreManager } from '@/lib/firebase-mock'
 import { getLogger } from '@/lib/logger'
 import { getStaticData } from '@/lib/store'
 
@@ -49,7 +51,7 @@ export function getFirebaseApp(): FirebaseApp {
   return firebaseApp
 }
 
-export class FirestoreManager {
+export class FirestoreManager implements IFirestoreManager {
   private readonly firestore: Firestore
 
   constructor(firestore: Firestore) {
@@ -120,16 +122,16 @@ export class FirestoreManager {
   }
 }
 
-let firestoreManager: FirestoreManager | null = null
+let firestoreManager: IFirestoreManager | null = null
 
-export function getFirestoreManager(): FirestoreManager {
+export function getFirestoreManager(): IFirestoreManager {
   if (!firestoreManager) {
     throw new Error('Firebase not initialized. Call _init first.')
   }
   return firestoreManager
 }
 
-export class AuthManager {
+export class AuthManager implements IAuthManager {
   private readonly auth: Auth
   private readonly brandId: number
   private userProfile: UserProfile | null = null
@@ -273,9 +275,9 @@ export class AuthManager {
   }
 }
 
-let authManager: AuthManager | null = null
+let authManager: IAuthManager | null = null
 
-export function getAuthManager(): AuthManager {
+export function getAuthManager(): IAuthManager {
   if (!authManager) {
     throw new Error('Firebase not initialized. Call _init first.')
   }
@@ -283,7 +285,26 @@ export function getAuthManager(): AuthManager {
 }
 
 export async function _init() {
-  const { brandId, config } = getStaticData()
+  const { brandId, config, testHooks } = getStaticData()
+
+  // Test-only hatch: when InitParams.testHooks is set, swap in mock managers
+  // and skip Firebase entirely. Production callers never set this field, so
+  // the real init path below runs unchanged. See src/lib/firebase-mock.ts.
+  if (testHooks !== undefined) {
+    const seedDocs: Record<string, Record<string, Record<string, unknown>>> = {
+      ...(testHooks.firestore?.docs ?? {}),
+    }
+    if (testHooks.auth?.profile) {
+      seedDocs.users = {
+        ...(seedDocs.users ?? {}),
+        [testHooks.auth.uid]: testHooks.auth.profile as unknown as Record<string, unknown>,
+      }
+    }
+    firestoreManager = new MockFirestoreManager(seedDocs)
+    authManager = new MockAuthManager(testHooks.auth ?? null, firestoreManager)
+    logger.logDebug('Firebase initialized in MOCK mode (testHooks present)')
+    return
+  }
 
   // Initialize Firebase App
   {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { Config } from '@/lib/config'
 import type { AuthUser, UserProfile } from '@/lib/firebase'
+import type { TestHooks } from '@/lib/firebase-mock'
 import type { FittingRoomItem } from '@/lib/fitting-room-storage'
 import { writeFittingRoom } from '@/lib/fitting-room-storage'
 import type { LoadedProductData, LoadedProductError } from '@/lib/product'
@@ -47,6 +48,10 @@ export interface StaticData {
   productLookup: ProductLookup | null
   getOverlayTopOffset: GetOverlayTopOffset | null
   addToCart: AddToCart | null
+  // Test-only data hatch. Production callers MUST NOT set this. When present,
+  // src/lib/firebase.ts:_init swaps the real Firebase Auth + Firestore for
+  // in-memory mocks seeded from this object. See src/lib/firebase-mock.ts.
+  testHooks?: TestHooks
 }
 
 let staticData: StaticData | null = null

--- a/tests/e2e/add-to-fitting-room.spec.ts
+++ b/tests/e2e/add-to-fitting-room.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+import { TEST_BRAND_ID, TEST_PRODUCT_EXTERNAL_ID } from './fixtures/seed'
+
+// Locks in the hanger-toggle UI state + the zustand store + the localStorage
+// write under the `tfr:fitting-room:v1` key. If any link in that chain breaks,
+// this test fails.
+test('hanger toggle adds the current product to fitting-room storage', async ({ page }) => {
+  await bootSdk(page)
+
+  // Pre-click state: aria-label "Add to Fitting Room", aria-pressed="false"
+  const button = page.getByRole('button', { name: 'Add to Fitting Room' })
+  await expect(button).toHaveAttribute('aria-pressed', 'false')
+
+  await button.click()
+
+  // Post-click state: aria-label flips to "In Fitting Room", pressed=true.
+  await expect(page.getByRole('button', { name: 'In Fitting Room' })).toHaveAttribute('aria-pressed', 'true')
+
+  // localStorage roundtrip — entry must land under the brand-id key.
+  const stored = await page.evaluate((brandId) => {
+    const raw = window.localStorage.getItem('tfr:fitting-room:v1')
+    return raw ? (JSON.parse(raw) as Record<string, { externalId: string }[]>)[String(brandId)] : null
+  }, TEST_BRAND_ID)
+
+  expect(stored).not.toBeNull()
+  expect(stored?.length).toBe(1)
+  expect(stored?.[0].externalId).toBe(TEST_PRODUCT_EXTERNAL_ID)
+})

--- a/tests/e2e/api-error-handling.spec.ts
+++ b/tests/e2e/api-error-handling.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+
+// Proves the mock-overrides path works (driving a per-test API failure) and
+// locks in "API failure does not crash the SDK" — the failure should be caught
+// and logged, not propagated as an uncaught error to the host page.
+test('500 on /v1/style-categories does not surface as a pageerror', async ({ page }) => {
+  const pageErrors: Error[] = []
+  page.on('pageerror', (err) => pageErrors.push(err))
+
+  await bootSdk(page, {
+    apiOverrides: {
+      styleCategories: (route) => route.fulfill({ status: 500, json: { error: 'simulated server error' } }),
+    },
+  })
+
+  await page.getByRole('button', { name: 'Fitting Room', exact: true }).click()
+
+  // Give the SDK a beat to attempt + handle the rejected request.
+  await page.waitForTimeout(500)
+
+  expect(pageErrors, `Unexpected page errors:\n${pageErrors.map((e) => e.stack ?? e.message).join('\n---\n')}`).toEqual(
+    [],
+  )
+})

--- a/tests/e2e/fitting-room-icon-opens-overlay.spec.ts
+++ b/tests/e2e/fitting-room-icon-opens-overlay.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+import { TEST_ID_TOKEN } from './fixtures/seed'
+
+// Locks in three things at once: the widget click path, REST mocking against
+// the real API base URL, and the auth-bearer wiring from MockAuthManager
+// through getAuthToken() into the api.ts request layer.
+test('clicking the fitting-room icon opens the overlay and fires /v1/style-categories with the auth bearer', async ({
+  page,
+}) => {
+  await bootSdk(page)
+
+  // Wait for the request, then click. waitForRequest is set up first so the
+  // listener is attached before the click can race past it.
+  const stylesReq = page.waitForRequest((req) => req.url().endsWith('/v1/style-categories'), { timeout: 10_000 })
+
+  // The fitting-room icon widget renders a <button aria-label="Fitting Room">
+  // (locale key `view_fitting_room`). `exact: true` disambiguates from the
+  // hanger toggle ("Add to Fitting Room" / "In Fitting Room").
+  await page.getByRole('button', { name: 'Fitting Room', exact: true }).click()
+
+  const req = await stylesReq
+  expect(req.headers()['authorization']).toBe(`Bearer ${TEST_ID_TOKEN}`)
+})

--- a/tests/e2e/fixtures/host.html
+++ b/tests/e2e/fixtures/host.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TFR SDK e2e test host</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 24px;
+      }
+      main {
+        max-width: 640px;
+      }
+      form {
+        display: grid;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      label {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <!-- Minimal Shopify-free analog of shopify/assets/tfr.js. The PDP-flavoured
+         widgets need a size/colour selector + an add-to-cart button to behave
+         realistically; the SDK reads them through the currentProduct callbacks
+         supplied below. -->
+      <h1>Test host</h1>
+      <form id="product-form">
+        <label
+          >Size:
+          <select name="Size">
+            <option value="S">S</option>
+            <option value="M" selected>M</option>
+          </select>
+        </label>
+        <label
+          >Color:
+          <select name="Color">
+            <option value="Blue" selected>Blue</option>
+            <option value="Red">Red</option>
+          </select>
+        </label>
+        <button name="add" type="submit">Add to cart</button>
+      </form>
+
+      <tfr-widget widget="size-rec"></tfr-widget>
+      <tfr-widget widget="add-to-fitting-room-compact"></tfr-widget>
+      <tfr-widget widget="vto-button"></tfr-widget>
+      <tfr-widget widget="fitting-room-icon"></tfr-widget>
+    </main>
+
+    <script type="module">
+      // Per-test config is injected via Playwright's `addInitScript` before this
+      // module runs. The SDK only reads `testHooks` from `InitParams` — the
+      // `window.__TFR_TEST_CONFIG__` lookup lives here in the test fixture,
+      // never inside src/.
+      const cfg = window.__TFR_TEST_CONFIG__ || {}
+
+      // Build the currentProduct adapter with the callbacks tests expect.
+      let currentProduct = null
+      if (cfg.currentProduct) {
+        const cp = cfg.currentProduct
+        currentProduct = {
+          ...cp,
+          getSelectedOptions: () => {
+            const size = document.querySelector('select[name="Size"]')?.value || ''
+            const color = document.querySelector('select[name="Color"]')?.value || null
+            return { size, color }
+          },
+          addToCart: async (opts) => {
+            window.__TFR_TEST_PDP_ADD__ = opts
+          },
+        }
+      }
+
+      try {
+        const { init } = await import('/dist/index.js')
+        const ok = await init({
+          brandId: cfg.brandId ?? 1,
+          environment: cfg.environment ?? 'demo',
+          debug: true,
+          currentProduct,
+          productLookup: async () => [],
+          addToCart: async (externalId, opts) => {
+            window.__TFR_TEST_LAST_ADD__ = { externalId, opts }
+          },
+          getOverlayTopOffset: () => 0,
+          testHooks: cfg.testHooks,
+        })
+        window.__TFR_TEST_INIT_OK__ = ok
+        window.dispatchEvent(new CustomEvent('tfr:test:init-complete', { detail: { ok } }))
+      } catch (error) {
+        window.__TFR_TEST_INIT_ERROR__ = String(error)
+        window.dispatchEvent(new CustomEvent('tfr:test:init-error', { detail: { error: String(error) } }))
+      }
+    </script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/seed.ts
+++ b/tests/e2e/fixtures/seed.ts
@@ -1,0 +1,74 @@
+// Shared fixture data for the e2e suite. Keep narrowly typed where it crosses
+// the SDK boundary (TestHooks / API response shapes); the rest can stay loose
+// since the SDK is the only consumer and types are checked at use sites.
+
+import type { FirestoreUser } from '../../../src/api/gen/responses'
+
+export const TEST_BRAND_ID = 1
+export const TEST_UID = 'test-uid-1'
+export const TEST_EMAIL = 'test@example.com'
+export const TEST_ID_TOKEN = 'mock-id-token-abc123'
+export const TEST_PRODUCT_EXTERNAL_ID = 'gid://shopify/Product/12345'
+export const TEST_PRODUCT_HANDLE = 'test-product'
+export const TEST_STYLE_ID = 999
+
+// A "happy path" user profile: avatar created, so the SDK treats the user as
+// fully onboarded and won't redirect to the GET_APP / LANDING overlays.
+export const TEST_USER_PROFILE: FirestoreUser = {
+  brand_id: TEST_BRAND_ID,
+  full_name: 'Test Shopper',
+  job: '',
+  avatar_status: 'CREATED',
+  avatar_gender: 'female',
+  avatar_frames: ['user-test/avatar-1/frames/image_0.png', 'user-test/avatar-1/frames/image_1.png'],
+  is_tos_accepted: true,
+  is_gte_18: true,
+  // Timestamp fields are read via `firebaseDateToDayjs` only inside the
+  // login-throttle path, which MockAuthManager skips entirely — so plain
+  // sentinels are fine here. Cast keeps the FirestoreUser type honest.
+  created_at: { seconds: 0, nanoseconds: 0 } as unknown as FirestoreUser['created_at'],
+}
+
+// Minimal ExternalProduct shape for currentProduct on PDP-flavoured tests.
+export const TEST_CURRENT_PRODUCT = {
+  productName: 'Test Product',
+  productDescriptionHtml: '<p>Test description</p>',
+  externalId: TEST_PRODUCT_EXTERNAL_ID,
+  handle: TEST_PRODUCT_HANDLE,
+  imageUrl: null,
+  variants: [
+    {
+      sku: 'SKU-M-BLUE',
+      size: 'M',
+      color: 'Blue',
+      fullName: 'Test M Blue',
+      skuName: 'SKU-M-BLUE',
+      priceFormatted: '$50.00',
+      imageUrl: null,
+    },
+    {
+      sku: 'SKU-S-BLUE',
+      size: 'S',
+      color: 'Blue',
+      fullName: 'Test S Blue',
+      skuName: 'SKU-S-BLUE',
+      priceFormatted: '$50.00',
+      imageUrl: null,
+    },
+  ],
+}
+
+// API response fixtures. Defaults are deliberately empty — tests that exercise
+// downstream UI flows can override per-test via installApiMocks.
+export const EMPTY_STYLE_CATEGORIES: unknown[] = []
+export const EMPTY_STYLE_CATEGORY_GROUPS: unknown[] = []
+export const EMPTY_SIZE_RECOMMENDATION = {
+  recommended_size: { size: 'M', size_label: 'M' },
+  fit_classification: 'regular_fit',
+  fits: [],
+  available_sizes: [],
+}
+export const TEST_VTO_COMPOSITION = {
+  token: 'tok-test-1',
+  frames: ['user-test/avatar-1/vto-tok-test-1/frames/image_0.png'],
+}

--- a/tests/e2e/helpers/boot.ts
+++ b/tests/e2e/helpers/boot.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test'
+import { installApiMocks, type ApiMockOverrides } from '../mocks/api'
+import {
+  TEST_BRAND_ID,
+  TEST_CURRENT_PRODUCT,
+  TEST_EMAIL,
+  TEST_ID_TOKEN,
+  TEST_UID,
+  TEST_USER_PROFILE,
+} from '../fixtures/seed'
+
+export interface BootSdkOptions {
+  // Override pieces of the default test config. Anything not specified gets
+  // the happy-path defaults from fixtures/seed.ts.
+  brandId?: number
+  currentProduct?: typeof TEST_CURRENT_PRODUCT | null
+  loggedIn?: boolean // default true (seeds TestHooks.auth with the standard test user)
+  apiOverrides?: ApiMockOverrides
+}
+
+/**
+ * Boot the SDK in the test host fixture with sensible defaults. Returns once
+ * `init(...)` has resolved (signalled by the `tfr:test:init-complete` event
+ * the host fixture dispatches).
+ */
+export async function bootSdk(page: Page, options: BootSdkOptions = {}): Promise<void> {
+  const { brandId = TEST_BRAND_ID, currentProduct = TEST_CURRENT_PRODUCT, loggedIn = true, apiOverrides } = options
+
+  await installApiMocks(page, apiOverrides)
+
+  // Build the test config and stash it on `window` BEFORE the page's inline
+  // script runs. The fixture HTML reads `__TFR_TEST_CONFIG__` and threads it
+  // into `init({ ..., testHooks })`.
+  await page.addInitScript(
+    ({ brandId, currentProduct, loggedIn, uid, email, idToken, profile }) => {
+      ;(window as unknown as { __TFR_TEST_CONFIG__: unknown }).__TFR_TEST_CONFIG__ = {
+        brandId,
+        environment: 'demo',
+        currentProduct,
+        testHooks: loggedIn ? { auth: { uid, email, idToken, profile } } : {},
+      }
+    },
+    {
+      brandId,
+      currentProduct,
+      loggedIn,
+      uid: TEST_UID,
+      email: TEST_EMAIL,
+      idToken: TEST_ID_TOKEN,
+      profile: TEST_USER_PROFILE,
+    },
+  )
+
+  await page.goto('/tests/e2e/fixtures/host.html')
+
+  // The fixture dispatches `tfr:test:init-complete` once init() resolves.
+  await page.waitForFunction(
+    () => (window as unknown as { __TFR_TEST_INIT_OK__?: boolean }).__TFR_TEST_INIT_OK__ === true,
+    undefined,
+    {
+      timeout: 10_000,
+    },
+  )
+}

--- a/tests/e2e/mocks/api.ts
+++ b/tests/e2e/mocks/api.ts
@@ -1,0 +1,72 @@
+import type { Page, Route } from '@playwright/test'
+import {
+  EMPTY_SIZE_RECOMMENDATION,
+  EMPTY_STYLE_CATEGORIES,
+  EMPTY_STYLE_CATEGORY_GROUPS,
+  TEST_VTO_COMPOSITION,
+} from '../fixtures/seed'
+
+// Per-test override hooks. Each receives the matched Route — call .fulfill /
+// .abort / .continue as needed. Omit a key to use the default fixture.
+export interface ApiMockOverrides {
+  sizeRecommendation?: (route: Route) => Promise<void> | void
+  styleCategories?: (route: Route) => Promise<void> | void
+  styleCategoryGroups?: (route: Route) => Promise<void> | void
+  vtoComposition?: (route: Route) => Promise<void> | void
+  frames?: (route: Route) => Promise<void> | void
+}
+
+// 1x1 transparent PNG. Frame requests (avatar + VTO) hit `applyFrameBaseUrl`
+// which prepends `config.frames.baseUrl` — so the catch-all matches any host
+// once the path suffix is .png/.jpg/etc.
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+  'base64',
+)
+
+/**
+ * Install REST-API mocks on the page. Routes are matched by path-suffix
+ * regex so they work regardless of which `config.api.baseUrl` (demo / local /
+ * dev / prod) the SDK is configured against.
+ *
+ * Order matters: more specific routes are registered first. Playwright tries
+ * the most recently added route first when multiple match.
+ */
+export async function installApiMocks(page: Page, overrides: ApiMockOverrides = {}): Promise<void> {
+  await page.route(/\/v1\/styles\/\d+\/recommendation$/, (route) => {
+    if (overrides.sizeRecommendation) {
+      return overrides.sizeRecommendation(route)
+    }
+    return route.fulfill({ json: EMPTY_SIZE_RECOMMENDATION })
+  })
+
+  await page.route(/\/v1\/style-categories$/, (route) => {
+    if (overrides.styleCategories) {
+      return overrides.styleCategories(route)
+    }
+    return route.fulfill({ json: EMPTY_STYLE_CATEGORIES })
+  })
+
+  await page.route(/\/v1\/style-category-groups$/, (route) => {
+    if (overrides.styleCategoryGroups) {
+      return overrides.styleCategoryGroups(route)
+    }
+    return route.fulfill({ json: EMPTY_STYLE_CATEGORY_GROUPS })
+  })
+
+  await page.route(/\/v1\/vto-compositions$/, (route) => {
+    if (overrides.vtoComposition) {
+      return overrides.vtoComposition(route)
+    }
+    return route.fulfill({ json: TEST_VTO_COMPOSITION })
+  })
+
+  // Catch-all for frame images. Must come last so the more specific REST
+  // routes above take precedence.
+  await page.route(/\.(png|jpg|jpeg|webp)(\?.*)?$/i, (route) => {
+    if (overrides.frames) {
+      return overrides.frames(route)
+    }
+    return route.fulfill({ contentType: 'image/png', body: PNG_1X1 })
+  })
+}

--- a/tests/e2e/sdk-boots.spec.ts
+++ b/tests/e2e/sdk-boots.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+
+// Boot smoke test: proves the whole pipeline — build → serve → host fixture →
+// SDK init({ testHooks }) → custom element registration — works end to end.
+test('SDK boots in mock mode and registers the <tfr-widget> custom element', async ({ page }) => {
+  await bootSdk(page)
+
+  // init() resolved truthy (the bootSdk helper waits for the event, but assert
+  // it explicitly here so the failure message points at the right thing).
+  const initOk = await page.evaluate(
+    () => (window as unknown as { __TFR_TEST_INIT_OK__?: boolean }).__TFR_TEST_INIT_OK__,
+  )
+  expect(initOk).toBe(true)
+
+  const widgetDefined = await page.evaluate(() => customElements.get('tfr-widget') !== undefined)
+  expect(widgetDefined).toBe(true)
+})


### PR DESCRIPTION
Stands up a minimal Playwright harness against the built bundle. Four specs
ship as proof of life; the framework supports expansion without rework.

## Mocking strategy

**Firebase is mocked, not emulated.** `InitParams.testHooks` is a data-only
test hatch — when present, `src/lib/firebase.ts:_init` swaps in
`MockAuthManager` + `MockFirestoreManager` (`src/lib/firebase-mock.ts`)
instead of initializing real Firebase. The branch lives in **exactly one
place**; no other file in `src/` knows about test mode and the SDK never
reads `window.X` for test flags. Production callers must not set the field
(documented JSDoc on the type).

`AuthManager` + `FirestoreManager` are now also typed against `IAuthManager`
/ `IFirestoreManager` interfaces — the module variables in `firebase.ts`
hold the interface type, so call sites stay unchanged regardless of which
implementation is installed.

REST endpoints (`/v1/styles/{id}/recommendation`, `/v1/style-categories`,
`/v1/style-category-groups`, `/v1/vto-compositions`) are mocked via
Playwright \`page.route()\` from \`tests/e2e/mocks/api.ts\`. Per-test
overrides drive error paths.

## The 4 specs

1. **sdk-boots** — bundle loads, init resolves true, `<tfr-widget>`
   custom element is registered. Proves the whole pipeline.
2. **fitting-room-icon-opens-overlay** — click the icon → overlay opens
   → \`GET /v1/style-categories\` fires with \`Authorization: Bearer
   <idToken>\`. Locks in UI-click → store → API + auth wiring.
3. **add-to-fitting-room** — hanger toggle flips \`aria-pressed\`;
   \`localStorage['tfr:fitting-room:v1']\` contains the expected entry.
4. **api-error-handling** — \`/v1/style-categories\` mocked to 500; no
   \`pageerror\` events. Proves per-test overrides + graceful failure.

Deferred follow-up: full VTO end-to-end (POST + frame rendering) needs
deep product/CSA fixtures. The design supports adding it without rework.

## CI + scripts

- \`.github/workflows/build.yml\` gets \`Install Playwright browsers\` →
  \`E2E tests\` → conditional report upload on failure.
- New scripts: \`test:e2e\`, \`test:e2e:debug\`, \`test:e2e:ui\`, \`test\`
  (alias). \`npm run check\` stays cheap (tsc + lint + format) — e2e is
  separate.
- ESLint flat config picks up \`tests/**/*.ts\` + \`playwright.config.ts\`
  with a no-type-aware block (tests aren't in tsconfig.json's include).
- Prettier scope expanded to cover tests + playwright config.

## Verification

- \`npm run check\` → 0 errors (13 pre-existing exhaustive-deps warnings).
- \`npm run build\` → \`dist/index.js\` 1,764 KB (+ ~5 KB vs main for the
  mock module + interface refactor).
- \`npm run test:e2e\` → 4 passed in ~2s locally.
- \`grep -rn '__TFR_TEST' src/\` → zero hits (constraint satisfied).
- \`testHooks\` references confined to: \`index.tsx\` (type + threading),
  \`store.ts\` (StaticData field), \`firebase.ts\` (the single branch),
  \`firebase-mock.ts\` (definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)