### PR TITLE
Quick-view + fitting-room overlay fixes (group label, zoom drag, color selector, fit-box padding)

### DIFF
--- a/src/components/color-selector.tsx
+++ b/src/components/color-selector.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import { TextT } from '@/components/text'
+import { useCss } from '@/lib/theme'
+
+export interface ColorSelectorProps {
+  availableColorLabels: string[]
+  selectedColorLabel: string | null
+  onChangeColor: (newColorLabel: string | null) => void
+}
+
+// Color dropdown shared by quick-view and the fitting-room detail accordion.
+// Renders nothing when fewer than two colours are available — the selector
+// would otherwise show a single locked option.
+export function ColorSelector({ availableColorLabels, selectedColorLabel, onChangeColor }: ColorSelectorProps) {
+  const css = useCss((theme) => ({
+    colorContainer: {},
+    colorLabelText: {
+      fontSize: '12px',
+    },
+    colorSelect: {
+      border: 'none',
+      color: theme.color_fg_text,
+      fontFamily: theme.font_family,
+      fontSize: '12px',
+    },
+  }))
+
+  const handleColorSelectChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newColorLabel = e.target.value || null
+      onChangeColor(newColorLabel)
+    },
+    [onChangeColor],
+  )
+
+  if (availableColorLabels.length < 2) {
+    return null
+  }
+  return (
+    <div css={css.colorContainer}>
+      <label>
+        <TextT variant="base" css={css.colorLabelText} t="quick-view.color_label" />
+        <select value={selectedColorLabel ?? ''} onChange={handleColorSelectChange} css={css.colorSelect}>
+          {availableColorLabels.map((colorLabel) => (
+            <option key={colorLabel} value={colorLabel}>
+              {colorLabel}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}

--- a/src/components/overlays/fitting-room/desktop-layout.tsx
+++ b/src/components/overlays/fitting-room/desktop-layout.tsx
@@ -42,6 +42,7 @@ interface DesktopLayoutProps {
   onOpenAccordionItem: (externalId: string | null) => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (externalId: string, sizeLabel: string) => void
+  onChangeColor: (externalId: string, colorLabel: string | null) => void
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
   onSignOut: () => void
@@ -63,6 +64,7 @@ export function DesktopLayout({
   onOpenAccordionItem,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
   onSignOut,
@@ -218,6 +220,7 @@ export function DesktopLayout({
             onOpenItem={onOpenAccordionItem}
             onChangeDetailMode={onChangeDetailMode}
             onChangeSize={onChangeSize}
+            onChangeColor={onChangeColor}
             onAddToCart={onAddToCart}
             onToggleUntuck={onToggleUntuck}
           />

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -242,17 +242,20 @@ function DesktopAccordionItem({
       width: '100%',
       marginTop: '8px',
     },
+    // 14px on these three text lines matches quick-view's fit-box (which
+    // relies on Text's base-variant default — 14px). Same look across both
+    // overlays.
     recommendedSize: {
-      fontSize: '13px',
+      fontSize: '14px',
       fontWeight: '600',
       lineHeight: 'normal',
     },
     selectPrompt: {
-      fontSize: '12px',
+      fontSize: '14px',
       lineHeight: 'normal',
     },
     fitText: {
-      fontSize: '12px',
+      fontSize: '14px',
       lineHeight: 'normal',
       // Tight 8px lift to the recommended-size line above; matches
       // quick-view's `itemFitContainer` marginTop.

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -242,21 +242,25 @@ function DesktopAccordionItem({
       width: '100%',
       marginTop: '8px',
     },
-    // 14px on these three text lines matches quick-view's fit-box (which
-    // relies on Text's base-variant default — 14px). Same look across both
-    // overlays.
+    // 14px / line-height 1.5 on these three text lines matches quick-view's
+    // fit-box. Quick-view's first line wraps an InfoIcon button alongside
+    // the recommended-size text, which stretches that line vertically; the
+    // simpler line-height bump here matches the *visual* line spacing
+    // without dragging the icon in. The two lines below it inherit
+    // line-height from their containers in quick-view, which the host page's
+    // body styles tend to set looser than Inter's intrinsic `normal` (~1.21).
     recommendedSize: {
       fontSize: '14px',
       fontWeight: '600',
-      lineHeight: 'normal',
+      lineHeight: 1.5,
     },
     selectPrompt: {
       fontSize: '14px',
-      lineHeight: 'normal',
+      lineHeight: 1.5,
     },
     fitText: {
       fontSize: '14px',
-      lineHeight: 'normal',
+      lineHeight: 1.5,
       // Tight 8px lift to the recommended-size line above; matches
       // quick-view's `itemFitContainer` marginTop.
       marginTop: '8px',

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -223,6 +223,11 @@ function DesktopAccordionItem({
     },
     // Padding matches quick-view's sizeRecommendationFrame (32px / 56px) so
     // the "fit box" feels visually consistent between the two overlays.
+    //
+    // No flex `gap` — the three text lines (recommended size, fit text,
+    // select-a-size prompt) sit tight against each other (matching
+    // quick-view), with explicit marginTop on the size selector + fit
+    // details below them to introduce the larger break.
     sizeBox: {
       width: '100%',
       border: `1px solid ${theme.color_fg_text}`,
@@ -230,7 +235,6 @@ function DesktopAccordionItem({
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
-      gap: '12px',
       marginTop: '8px',
       textAlign: 'center',
     },
@@ -241,21 +245,29 @@ function DesktopAccordionItem({
     recommendedSize: {
       fontSize: '13px',
       fontWeight: '600',
+      lineHeight: 'normal',
     },
     selectPrompt: {
       fontSize: '12px',
+      lineHeight: 'normal',
     },
     fitText: {
       fontSize: '12px',
+      lineHeight: 'normal',
+      // Tight 8px lift to the recommended-size line above; matches
+      // quick-view's `itemFitContainer` marginTop.
+      marginTop: '8px',
     },
     fitDetails: {
       width: '100%',
+      marginTop: '24px',
     },
     sizeRow: {
       display: 'flex',
       gap: '8px',
       alignItems: 'center',
       justifyContent: 'center',
+      marginTop: '24px',
     },
     cartContainer: {
       width: '100%',

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { AddToCartButton } from '@/components/add-to-cart-button'
 import { Button } from '@/components/button'
+import { ColorSelector } from '@/components/color-selector'
 import { ItemFitDetails } from '@/components/item-fit-details'
 import { ItemFitText } from '@/components/item-fit-text'
 import { LinkT } from '@/components/link'
@@ -29,6 +30,7 @@ interface DetailAccordionItemProps {
   onToggleOpen: () => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (sizeLabel: string) => void
+  onChangeColor: (colorLabel: string | null) => void
   onAddToCart: () => void
   onToggleUntuck: () => void
 }
@@ -44,6 +46,7 @@ export function DetailAccordionItem({
   onToggleOpen,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
 }: DetailAccordionItemProps) {
@@ -83,6 +86,19 @@ export function DetailAccordionItem({
     return null
   }, [productData, item.storage.colorwaySizeAssetId])
 
+  // Available colours for the currently-selected size. Drives the colour
+  // dropdown; ColorSelector hides itself when there are fewer than two.
+  const availableColorLabels = useMemo<string[]>(() => {
+    if (!productData || !selectedSizeLabel) {
+      return []
+    }
+    const sizeRec = productData.sizes.find((s) => s.sizeLabel === selectedSizeLabel)
+    if (!sizeRec) {
+      return []
+    }
+    return sizeRec.colors.map((c) => c.colorLabel).filter((label): label is string => !!label)
+  }, [productData, selectedSizeLabel])
+
   const categoryLabel = item.styleCategory?.label_singular ?? item.styleCategory?.label ?? ''
   const productName = item.merchantProduct?.productName ?? item.externalId
   // Mobile tuck CTA shows only when this item is tuckable AND the outfit has
@@ -97,8 +113,11 @@ export function DetailAccordionItem({
         productData={productData}
         currentPrice={currentPrice}
         selectedSizeLabel={selectedSizeLabel}
+        availableColorLabels={availableColorLabels}
+        selectedColorLabel={item.storage.color}
         onToggleOpen={onToggleOpen}
         onChangeSize={onChangeSize}
+        onChangeColor={onChangeColor}
         onAddToCart={onAddToCart}
       />
     )
@@ -111,6 +130,8 @@ export function DetailAccordionItem({
       productName={productName}
       productData={productData}
       selectedSizeLabel={selectedSizeLabel}
+      availableColorLabels={availableColorLabels}
+      selectedColorLabel={item.storage.color}
       currentPrice={currentPrice}
       detailMode={detailMode}
       isMobileQuickRow={isMobileQuickRow}
@@ -119,6 +140,7 @@ export function DetailAccordionItem({
       onToggleOpen={onToggleOpen}
       onChangeDetailMode={onChangeDetailMode}
       onChangeSize={onChangeSize}
+      onChangeColor={onChangeColor}
       onAddToCart={onAddToCart}
       onToggleUntuck={onToggleUntuck}
     />
@@ -131,8 +153,11 @@ interface DesktopProps {
   productData: VtoProductData | null
   currentPrice: string | null
   selectedSizeLabel: string | null
+  availableColorLabels: string[]
+  selectedColorLabel: string | null
   onToggleOpen: () => void
   onChangeSize: (sizeLabel: string) => void
+  onChangeColor: (colorLabel: string | null) => void
   onAddToCart: () => void
 }
 
@@ -142,8 +167,11 @@ function DesktopAccordionItem({
   productData,
   currentPrice,
   selectedSizeLabel,
+  availableColorLabels,
+  selectedColorLabel,
   onToggleOpen,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
 }: DesktopProps) {
   // Subtle neutral grey used both as the accordion header background and as
@@ -193,16 +221,22 @@ function DesktopAccordionItem({
     price: {
       fontSize: '15px',
     },
+    // Padding matches quick-view's sizeRecommendationFrame (32px / 56px) so
+    // the "fit box" feels visually consistent between the two overlays.
     sizeBox: {
       width: '100%',
       border: `1px solid ${theme.color_fg_text}`,
-      padding: '20px 24px',
+      padding: '32px 56px',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
       gap: '12px',
       marginTop: '8px',
       textAlign: 'center',
+    },
+    colorSelectorContainer: {
+      width: '100%',
+      marginTop: '8px',
     },
     recommendedSize: {
       fontSize: '13px',
@@ -257,6 +291,13 @@ function DesktopAccordionItem({
                   {currentPrice}
                 </Text>
               ) : null}
+              <div css={css.colorSelectorContainer}>
+                <ColorSelector
+                  availableColorLabels={availableColorLabels}
+                  selectedColorLabel={selectedColorLabel}
+                  onChangeColor={onChangeColor}
+                />
+              </div>
               <div css={css.sizeBox}>
                 <Text variant="base" css={css.recommendedSize}>
                   Recommended Size: {productData.recommendedSizeLabel}
@@ -296,6 +337,8 @@ interface MobileProps {
   productName: string
   productData: VtoProductData | null
   selectedSizeLabel: string | null
+  availableColorLabels: string[]
+  selectedColorLabel: string | null
   currentPrice: string | null
   detailMode: DetailMode
   isMobileQuickRow: boolean
@@ -304,6 +347,7 @@ interface MobileProps {
   onToggleOpen: () => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (sizeLabel: string) => void
+  onChangeColor: (colorLabel: string | null) => void
   onAddToCart: () => void
   onToggleUntuck: () => void
 }
@@ -314,6 +358,8 @@ function MobileAccordionItem({
   productName,
   productData,
   selectedSizeLabel,
+  availableColorLabels,
+  selectedColorLabel,
   currentPrice,
   detailMode,
   isMobileQuickRow,
@@ -322,6 +368,7 @@ function MobileAccordionItem({
   onToggleOpen,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
 }: MobileProps) {
@@ -496,6 +543,11 @@ function MobileAccordionItem({
                     onChangeSize={onChangeSize}
                   />
                 </div>
+                <ColorSelector
+                  availableColorLabels={availableColorLabels}
+                  selectedColorLabel={selectedColorLabel}
+                  onChangeColor={onChangeColor}
+                />
                 <ItemFitText loadedProductData={productData} />
                 <div css={css.fitDetailsContainer}>
                   <ItemFitDetails loadedProductData={productData} selectedSizeLabel={selectedSizeLabel} />

--- a/src/components/overlays/fitting-room/detail-accordion.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion.tsx
@@ -15,6 +15,7 @@ interface DetailAccordionProps {
   onOpenItem: (externalId: string | null) => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (externalId: string, sizeLabel: string) => void
+  onChangeColor: (externalId: string, colorLabel: string | null) => void
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
 }
@@ -33,6 +34,7 @@ export function DetailAccordion({
   onOpenItem,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
 }: DetailAccordionProps) {
@@ -63,6 +65,7 @@ export function DetailAccordion({
             onToggleOpen={() => onOpenItem(isOpen ? null : item.externalId)}
             onChangeDetailMode={onChangeDetailMode}
             onChangeSize={(label) => onChangeSize(item.externalId, label)}
+            onChangeColor={(label) => onChangeColor(item.externalId, label)}
             onAddToCart={() => onAddToCart(item.externalId)}
             onToggleUntuck={onToggleUntuck}
           />

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -237,6 +237,31 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
     [resolved.items, updateFittingRoomItem],
   )
 
+  // Mirror handleChangeSize but vary the colour for the currently-stored size.
+  // Resolves to a CSA via findCsaByLabel and writes the new size/color/csaId.
+  const handleChangeColor = useCallback(
+    (externalId: string, colorLabel: string | null) => {
+      const item = resolved.items.find((i) => i.externalId === externalId)
+      if (!item || !item.storage.size) {
+        return
+      }
+      const productData = buildVtoProductDataFromResolved(item)
+      if (!productData) {
+        return
+      }
+      const csa = findCsaByLabel(productData, item.storage.size, colorLabel)
+      if (!csa) {
+        return
+      }
+      updateFittingRoomItem(externalId, {
+        colorwaySizeAssetId: csa.colorwaySizeAssetId,
+        size: item.storage.size,
+        color: csa.colorLabel,
+      })
+    },
+    [resolved.items, updateFittingRoomItem],
+  )
+
   // Wire to the merchant's addToCart callback (StaticData) when configured.
   // The fitting-room may add ANY item, not just currentProduct — so we use the
   // top-level `addToCart` callback rather than `currentProduct.addToCart`.
@@ -504,6 +529,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             onOpenAccordionItem={setOpenAccordionItemId}
             onChangeDetailMode={setDetailMode}
             onChangeSize={handleChangeSize}
+            onChangeColor={handleChangeColor}
             onAddToCart={handleAddToCart}
             onToggleUntuck={handleToggleUntuck}
           />
@@ -522,6 +548,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             onOpenAccordionItem={setOpenAccordionItemId}
             onChangeDetailMode={setDetailMode}
             onChangeSize={handleChangeSize}
+            onChangeColor={handleChangeColor}
             onAddToCart={handleAddToCart}
             onToggleUntuck={handleToggleUntuck}
             onSignOut={handleSignOut}

--- a/src/components/overlays/fitting-room/mobile-layout.tsx
+++ b/src/components/overlays/fitting-room/mobile-layout.tsx
@@ -40,6 +40,7 @@ interface MobileLayoutProps {
   onOpenAccordionItem: (externalId: string | null) => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (externalId: string, sizeLabel: string) => void
+  onChangeColor: (externalId: string, colorLabel: string | null) => void
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
 }
@@ -66,6 +67,7 @@ export function MobileLayout({
   onOpenAccordionItem,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
 }: MobileLayoutProps) {
@@ -95,6 +97,7 @@ export function MobileLayout({
       onOpenAccordionItem={onOpenAccordionItem}
       onChangeDetailMode={onChangeDetailMode}
       onChangeSize={onChangeSize}
+      onChangeColor={onChangeColor}
       onAddToCart={onAddToCart}
       onToggleUntuck={onToggleUntuck}
     />
@@ -242,6 +245,7 @@ function TryOnView({
   onOpenAccordionItem,
   onChangeDetailMode,
   onChangeSize,
+  onChangeColor,
   onAddToCart,
   onToggleUntuck,
 }: {
@@ -257,6 +261,7 @@ function TryOnView({
   onOpenAccordionItem: (externalId: string | null) => void
   onChangeDetailMode: (mode: DetailMode) => void
   onChangeSize: (externalId: string, sizeLabel: string) => void
+  onChangeColor: (externalId: string, colorLabel: string | null) => void
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
 }) {
@@ -387,6 +392,7 @@ function TryOnView({
                 onOpenItem={onOpenAccordionItem}
                 onChangeDetailMode={onChangeDetailMode}
                 onChangeSize={onChangeSize}
+                onChangeColor={onChangeColor}
                 onAddToCart={onAddToCart}
                 onToggleUntuck={onToggleUntuck}
               />

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AddToCartButton } from '@/components/add-to-cart-button'
 import { AvatarFrameViewer } from '@/components/avatar-frame-viewer'
 import { Button } from '@/components/button'
+import { ColorSelector } from '@/components/color-selector'
 import { FitChart } from '@/components/content/fit-chart'
 import { Loading } from '@/components/content/loading'
 import { ItemFitDetails } from '@/components/item-fit-details'
@@ -28,6 +29,7 @@ import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
 import type { VtoProductData, VtoSizeColorData, VtoSizeData } from '@/lib/product'
 import { loadProductDataToStore } from '@/lib/product'
+import { loadStyleCategoryIndex } from '@/lib/style-categories'
 import { getStaticData, useMainStore } from '@/lib/store'
 import type { CssProp, StyleProp } from '@/lib/theme'
 import { getThemeData, useCss } from '@/lib/theme'
@@ -106,8 +108,13 @@ export default function QuickViewOverlay() {
         // Get user selections from page
         const { color: selectedColor } = await currentProduct.getSelectedOptions()
 
-        // Assemble vto product data
-        const styleCategoryLabel = storeProduct.style.style_category_label || null
+        // Assemble vto product data. The product-summary row shows the
+        // style-category *group* label (e.g. "Top"), not the per-category
+        // label — match the Figma. We resolve the group via the cached
+        // style-category index; loadStyleCategoryIndex is idempotent + cached.
+        const styleCategoryIndex = await loadStyleCategoryIndex()
+        const styleCategoryGroup = styleCategoryIndex.groupForCategory(storeProduct.style.style_category_name)
+        const styleCategoryLabel = styleCategoryGroup?.label ?? null
         const sizeRecommendationRecord = storeProduct.sizeFitRecommendation
         {
           const recommendedSizeId = sizeRecommendationRecord.recommended_size.id || null
@@ -1326,50 +1333,6 @@ function ProductSummaryRow({ loadedProductData }: ProductSummaryRowProps) {
           {loadedProductData.productName}
         </Text>
       </div>
-    </div>
-  )
-}
-
-interface ColorSelectorProps {
-  availableColorLabels: string[]
-  selectedColorLabel: string | null
-  onChangeColor: (newColorLabel: string | null) => void
-}
-
-function ColorSelector({ availableColorLabels, selectedColorLabel, onChangeColor }: ColorSelectorProps) {
-  const css = useCss((theme) => ({
-    colorContainer: {},
-    colorLabelText: {
-      fontSize: '12px',
-    },
-    colorSelect: {
-      border: 'none',
-      color: theme.color_fg_text,
-      fontFamily: theme.font_family,
-      fontSize: '12px',
-    },
-  }))
-
-  const handleColorSelectChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newColorLabel = e.target.value || null
-    onChangeColor(newColorLabel)
-  }, [])
-
-  if (availableColorLabels.length < 2) {
-    return null
-  }
-  return (
-    <div css={css.colorContainer}>
-      <label>
-        <TextT variant="base" css={css.colorLabelText} t="quick-view.color_label" />
-        <select value={selectedColorLabel ?? ''} onChange={handleColorSelectChange} css={css.colorSelect}>
-          {availableColorLabels.map((colorLabel) => (
-            <option key={colorLabel} value={colorLabel}>
-              {colorLabel}
-            </option>
-          ))}
-        </select>
-      </label>
     </div>
   )
 }

--- a/src/components/zoom-modal.tsx
+++ b/src/components/zoom-modal.tsx
@@ -1,8 +1,15 @@
-import type { Dispatch, SetStateAction } from 'react'
-import { useEffect } from 'react'
+import type { Dispatch, MouseEvent as ReactMouseEvent, SetStateAction } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useFrameRotation } from '@/components/use-frame-rotation'
 import { ChevronLeftIcon, ChevronRightIcon } from '@/lib/asset'
 import { useCss } from '@/lib/theme'
+
+// Pointer-pixel thresholds for the zoom modal's axis-locking image drag.
+// AXIS_LOCK_PX: how far the pointer moves before committing to scroll-or-rotate.
+// ROTATE_STEP_PX: pointer-px of horizontal travel per frame of rotation
+// (mirrors DRAG_STEP_PX in use-frame-rotation so the feel matches).
+const AXIS_LOCK_PX = 8
+const ROTATE_STEP_PX = 50
 
 interface ZoomModalProps {
   frameUrls: string[]
@@ -31,9 +38,66 @@ export function ZoomModal({ frameUrls, selectedFrameIndex, setSelectedFrameIndex
     return () => document.removeEventListener('keydown', onKeyDown, true)
   }, [onClose])
 
-  const { rotateLeft, rotateRight, handleMouseDragStart, handleTouchDragStart } = useFrameRotation(
-    frameUrls,
-    setSelectedFrameIndex,
+  const { rotateLeft, rotateRight } = useFrameRotation(frameUrls, setSelectedFrameIndex)
+
+  const scrollAreaRef = useRef<HTMLDivElement>(null)
+
+  // Image-drag handler with an axis lock: after the first AXIS_LOCK_PX of
+  // pointer travel, commit to either *scrolling* the inset scroll area
+  // (vertical-dominant drag) or *rotating* through frames (horizontal-dominant
+  // drag) for the rest of the gesture. This keeps the two interactions from
+  // fighting each other when the image overflows the inset.
+  //
+  // Touch is intentionally not wired up here — the scroll area is
+  // `overflow: auto`, so native touch scrolling pans the image; on mobile the
+  // chevrons handle rotation. Hijacking touchstart breaks native scrolling.
+  const handleImageMouseDown = useCallback(
+    (e: ReactMouseEvent) => {
+      e.preventDefault()
+      const startX = e.clientX
+      const startY = e.clientY
+      const scrollArea = scrollAreaRef.current
+      const startScrollTop = scrollArea?.scrollTop ?? 0
+      let mode: 'unknown' | 'scroll' | 'rotate' = 'unknown'
+      let lastRotateX = startX
+
+      const onMove = (move: MouseEvent) => {
+        const deltaX = move.clientX - startX
+        const deltaY = move.clientY - startY
+        if (mode === 'unknown') {
+          const absX = Math.abs(deltaX)
+          const absY = Math.abs(deltaY)
+          if (absX < AXIS_LOCK_PX && absY < AXIS_LOCK_PX) {
+            return
+          }
+          mode = absY > absX ? 'scroll' : 'rotate'
+          lastRotateX = move.clientX
+        }
+        if (mode === 'scroll' && scrollArea) {
+          // Pulling the image down should move the content downward under
+          // the pointer — i.e. scroll the viewport *upward*. scrollTop
+          // decreases as deltaY grows.
+          scrollArea.scrollTop = startScrollTop - deltaY
+        } else if (mode === 'rotate') {
+          const rotateDelta = move.clientX - lastRotateX
+          if (Math.abs(rotateDelta) >= ROTATE_STEP_PX) {
+            if (rotateDelta > 0) {
+              rotateRight()
+            } else {
+              rotateLeft()
+            }
+            lastRotateX = move.clientX
+          }
+        }
+      }
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove)
+        window.removeEventListener('mouseup', onUp)
+      }
+      window.addEventListener('mousemove', onMove)
+      window.addEventListener('mouseup', onUp)
+    },
+    [rotateLeft, rotateRight],
   )
 
   const css = useCss((_theme) => ({
@@ -117,15 +181,9 @@ export function ZoomModal({ frameUrls, selectedFrameIndex, setSelectedFrameIndex
 
   return (
     <div css={css.backdrop}>
-      <div css={css.scrollArea}>
+      <div ref={scrollAreaRef} css={css.scrollArea}>
         <div css={css.imageWrap}>
-          <img
-            src={imageUrl}
-            css={css.image}
-            alt=""
-            onMouseDown={handleMouseDragStart}
-            onTouchStart={handleTouchDragStart}
-          />
+          <img src={imageUrl} css={css.image} alt="" onMouseDown={handleImageMouseDown} />
         </div>
       </div>
       <div css={{ ...css.chevron, ...css.chevronLeft }} onClick={rotateLeft}>


### PR DESCRIPTION
Four targeted UX adjustments.

## 1. quick-view: show style-category group label, not category label

The product-summary row now reads the **group** label (e.g. \"Top\") instead
of the per-category label (e.g. \"T-shirts\"), matching the Figma.
\`setupInitialVtoData\` resolves the group via the existing style-category
index (\`loadStyleCategoryIndex\` is idempotent + cached).

## 2. zoom-modal: vertical click-drag scrolls; horizontal still rotates

The inset scroll area is \`overflow: auto\`, but desktop has no
drag-to-pan natively. New behaviour: image click-drag locks to an axis
after 8 px of pointer travel:

- vertical-dominant → scroll the scroll area (pan the zoomed frame up/down)
- horizontal-dominant → rotate through frames (unchanged behaviour)

Once locked, the gesture stays in that mode until release. Touch handler
is removed — mobile uses native touch scrolling for pan and the
chevrons for rotate. (Hijacking touchstart broke native scrolling.)

## 3. fitting-room product-detail: add the missing colour selector

Extracted \`ColorSelector\` from quick-view into
\`src/components/color-selector.tsx\` so both overlays share the
component (renders nothing when fewer than two colours are available).

Threaded \`onChangeColor\` through the same path as \`onChangeSize\`:
\`fitting-room/index.tsx\` → \`desktop-layout\` / \`mobile-layout\` →
\`detail-accordion\` → \`detail-accordion-item\`. \`handleChangeColor\`
mirrors \`handleChangeSize\`: resolves a CSA for the current size + new
colour via \`findCsaByLabel\` and writes the new \`{csaId, size, color}\`.

Selector appears below the price (desktop) and between the size selector
and fit text (mobile).

## 4. fitting-room desktop fit-box padding matches quick-view

\`DesktopAccordionItem.sizeBox.padding\` bumped from \`20px 24px\` to
\`32px 56px\` to match \`quick-view\`'s \`sizeRecommendationFrame\`.

## Verification

- \`npm run check\` clean (0 errors, 12 pre-existing warnings).
- \`npm run build\` produces \`dist/index.js\` (1768 KB).
- \`npm run test:e2e\` — all 4 specs pass in ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)