### PR TITLE
Quick-view + fitting-room: serif accents, lighter body weights

### DIFF
--- a/src/components/item-fit-details.tsx
+++ b/src/components/item-fit-details.tsx
@@ -59,7 +59,7 @@ export function ItemFitDetails({ loadedProductData, selectedSizeLabel }: ItemFit
         </div>
       )
     })
-  }, [loadedProductData, selectedSizeLabel])
+  }, [loadedProductData, selectedSizeLabel, t, css.detailCell, css.firstLine, css.line])
 
   return <div css={css.container}>{fitLineNodeList}</div>
 }

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -218,6 +218,7 @@ function DesktopAccordionItem({
     },
     productName: {
       fontSize: '24px',
+      fontWeight: '300',
       lineHeight: '1.2',
     },
     price: {
@@ -258,10 +259,12 @@ function DesktopAccordionItem({
     },
     selectPrompt: {
       fontSize: '14px',
+      fontWeight: '300',
       lineHeight: 1.5,
     },
     fitText: {
       fontSize: '14px',
+      fontWeight: '300',
       lineHeight: 1.5,
       // Tight 8px lift to the recommended-size line above; matches
       // quick-view's `itemFitContainer` marginTop.
@@ -269,6 +272,10 @@ function DesktopAccordionItem({
     },
     fitDetails: {
       width: '100%',
+      // Cascades to the text inside <ItemFitDetails>; the size-selector
+      // buttons and the bold recommended-size line above stay at their
+      // own weights.
+      fontWeight: 300,
       marginTop: '24px',
     },
     sizeRow: {
@@ -425,14 +432,14 @@ function MobileAccordionItem({
     },
     categoryLabel: {
       fontFamily: "'Times New Roman', serif",
-      fontSize: '15px',
+      fontSize: '16px',
       fontWeight: '400',
       letterSpacing: '0.04em',
       flex: 'none',
     },
     productName: {
       fontFamily: "'Times New Roman', serif",
-      fontSize: '15px',
+      fontSize: '16px',
       letterSpacing: '0.04em',
       color: '#8A8A8A',
       overflow: 'hidden',

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -194,6 +194,7 @@ function DesktopAccordionItem({
       backgroundColor: ACCORDION_SHADE,
     },
     categoryLabel: {
+      fontFamily: "'Times New Roman', serif",
       fontSize: '16px',
       fontWeight: '400',
     },
@@ -422,11 +423,13 @@ function MobileAccordionItem({
       minWidth: 0,
     },
     categoryLabel: {
+      fontFamily: "'Times New Roman', serif",
       fontSize: '15px',
       fontWeight: '400',
       flex: 'none',
     },
     productName: {
+      fontFamily: "'Times New Roman', serif",
       fontSize: '15px',
       color: '#8A8A8A',
       overflow: 'hidden',

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -195,8 +195,9 @@ function DesktopAccordionItem({
     },
     categoryLabel: {
       fontFamily: "'Times New Roman', serif",
-      fontSize: '16px',
+      fontSize: '20px',
       fontWeight: '400',
+      letterSpacing: '0.04em',
     },
     chevron: {
       display: 'inline-flex',
@@ -426,11 +427,13 @@ function MobileAccordionItem({
       fontFamily: "'Times New Roman', serif",
       fontSize: '15px',
       fontWeight: '400',
+      letterSpacing: '0.04em',
       flex: 'none',
     },
     productName: {
       fontFamily: "'Times New Roman', serif",
       fontSize: '15px',
+      letterSpacing: '0.04em',
       color: '#8A8A8A',
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/src/components/overlays/get-app.tsx
+++ b/src/components/overlays/get-app.tsx
@@ -56,7 +56,7 @@ export default function GetAppOverlay({ returnToOverlay, noAvatar }: GetAppOverl
 
   const handleSignInClick = useCallback(() => {
     openOverlay(OverlayName.SIGN_IN, { returnToOverlay })
-  }, [returnToOverlay])
+  }, [openOverlay, returnToOverlay])
   const handleGetAppAppleClick = useCallback(() => {
     const url = getStaticData().config.links.appAppleStoreUrl
     window.open(url, '_blank')

--- a/src/components/overlays/landing.tsx
+++ b/src/components/overlays/landing.tsx
@@ -47,10 +47,10 @@ export default function LandingOverlay({ returnToOverlay }: LandingOverlayProps)
 
   const handleGetAppClick = useCallback(() => {
     openOverlay(OverlayName.GET_APP, { returnToOverlay })
-  }, [returnToOverlay])
+  }, [openOverlay, returnToOverlay])
   const handleSignInClick = useCallback(() => {
     openOverlay(OverlayName.SIGN_IN, { returnToOverlay })
-  }, [returnToOverlay])
+  }, [openOverlay, returnToOverlay])
 
   return (
     <ContentModal onRequestClose={closeOverlay} title={<TextT variant="brand" css={css.titleText} t="try_it_on" />}>

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -109,12 +109,14 @@ export default function QuickViewOverlay() {
         const { color: selectedColor } = await currentProduct.getSelectedOptions()
 
         // Assemble vto product data. The product-summary row shows the
-        // style-category *group* label (e.g. "Top"), not the per-category
-        // label — match the Figma. We resolve the group via the cached
-        // style-category index; loadStyleCategoryIndex is idempotent + cached.
+        // per-category *singular* label (e.g. "Top"), matching what the
+        // fitting-room accordion header uses. The style-category group's
+        // label is plural ("Tops") and lacks a singular form, so we go
+        // through `byName` for the StyleCategory itself, which carries
+        // `label_singular`.
         const styleCategoryIndex = await loadStyleCategoryIndex()
-        const styleCategoryGroup = styleCategoryIndex.groupForCategory(storeProduct.style.style_category_name)
-        const styleCategoryLabel = styleCategoryGroup?.label ?? null
+        const styleCategoryRecord = styleCategoryIndex.byName(storeProduct.style.style_category_name)
+        const styleCategoryLabel = styleCategoryRecord?.label_singular ?? styleCategoryRecord?.label ?? null
         const sizeRecommendationRecord = storeProduct.sizeFitRecommendation
         {
           const recommendedSizeId = sizeRecommendationRecord.recommended_size.id || null
@@ -948,7 +950,9 @@ function DesktopLayout({
     },
     productNameContainer: {},
     productNameText: {
+      fontFamily: "'Inter', sans-serif",
       fontSize: '32px',
+      fontWeight: 300,
     },
     priceContainer: {
       marginTop: '8px',
@@ -982,17 +986,27 @@ function DesktopLayout({
       marginTop: '8px',
       lineHeight: 'normal',
     },
-    itemFitText: {},
+    itemFitText: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 300,
+    },
     selectSizeLabelContainer: {
       lineHeight: 'normal',
     },
-    selectSizeLabelText: {},
+    selectSizeLabelText: {
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 300,
+    },
     sizeSelectorContainer: {
       marginTop: '24px',
     },
     itemFitDetailsContainer: {
       marginTop: '24px',
       width: '100%',
+      // Cascades into <ItemFitDetails>; the bold recommended-size line above
+      // and the size-selector buttons stay at their own weights.
+      fontFamily: "'Inter', sans-serif",
+      fontWeight: 300,
     },
     fitChartContainer: {
       marginTop: '16px',
@@ -1314,10 +1328,14 @@ function ProductSummaryRow({ loadedProductData }: ProductSummaryRowProps) {
     },
     labelContainer: {},
     labelText: {
+      fontFamily: "'Times New Roman', serif",
+      fontSize: '16px',
       color: '#1A1A1A',
     },
     nameContainer: {},
     nameText: {
+      fontFamily: "'Times New Roman', serif",
+      fontSize: '16px',
       color: '#9F9F9F',
     },
   }))

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -299,7 +299,7 @@ export default function QuickViewOverlay() {
     authManager.logout().catch((error) => {
       logger.logError('Error during logout:', { error })
     })
-  }, [closeOverlay, openOverlay])
+  }, [closeOverlay])
   const handleAddToCartClick = useCallback(async () => {
     try {
       if (!selectedSizeLabel) {
@@ -315,7 +315,7 @@ export default function QuickViewOverlay() {
     } catch (error) {
       logger.logError('Error adding to cart:', { error })
     }
-  }, [selectedColorLabel, selectedSizeLabel])
+  }, [closeOverlay, selectedColorLabel, selectedSizeLabel])
 
   // RENDERING:
 
@@ -1259,7 +1259,7 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
     return () => {
       window.removeEventListener('resize', refreshLayoutData)
     }
-  }, [isMobileLayout])
+  }, [isMobileLayout, setModalStyle])
 
   // RENDERING:
 

--- a/src/components/overlays/sign-in.tsx
+++ b/src/components/overlays/sign-in.tsx
@@ -126,10 +126,10 @@ export default function SignInOverlay({ returnToOverlay }: SignInOverlayProps) {
   )
   const handleForgotPasswordClick = useCallback(() => {
     openOverlay(OverlayName.FORGOT_PASSWORD, { returnToOverlay })
-  }, [returnToOverlay])
+  }, [openOverlay, returnToOverlay])
   const handleGetAppClick = useCallback(() => {
     openOverlay(OverlayName.GET_APP, { returnToOverlay })
-  }, [returnToOverlay])
+  }, [openOverlay, returnToOverlay])
 
   return (
     <ContentModal onRequestClose={closeOverlay} title={<TfrTitle />}>

--- a/src/components/size-selector.tsx
+++ b/src/components/size-selector.tsx
@@ -47,7 +47,7 @@ export function SizeSelector({ loadedProductData, selectedSizeLabel, onChangeSiz
           </Button>
         )
       }),
-    [loadedProductData.sizes, selectedSizeLabel, onChangeSize],
+    [loadedProductData.sizes, selectedSizeLabel, onChangeSize, css.button, css.selectedButton],
   )
   return <div css={css.container}>{sizeSelectorNodeList}</div>
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -43,6 +43,10 @@ export { keyframes }
 // frozen. Closures over component state or props won't update. For style
 // values that need to react to state (e.g. dynamic grid template), apply
 // them via inline `style` instead of routing through useCss.
+/* eslint-disable react-hooks/exhaustive-deps -- both functions intentionally
+   memoize once on mount; the callback identity is ignored on purpose so that
+   `useCss((theme) => ({...}))` doesn't re-run every render. See useCss
+   docstring above. Reactive style values must use inline `style` instead. */
 export function useCss<T extends Record<string, CssProp>>(callback: (themeData: ThemeData) => T): T {
   return useMemo(() => callback(themeData), [])
 }
@@ -56,3 +60,4 @@ export function useVariantCss<T extends string, U extends Record<T, CssProp> = R
     return variants[variant]
   }, [variant])
 }
+/* eslint-enable react-hooks/exhaustive-deps */

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,9 @@
 /* Inter — the SDK's own typeface, matching the Figma designs. Loaded here so
-   overlay text renders in Inter regardless of the host page's fonts. */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+   overlay text renders in Inter regardless of the host page's fonts. The
+   variable-axis URL serves every integer weight from 100 to 900 in one file
+   so any `font-weight: <n>` value renders accurately without falling back to
+   the nearest pre-loaded weight. */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
 
 body.tfr-modal-open {
   overflow: hidden;


### PR DESCRIPTION
## Summary

A pass of font-weight and font-family adjustments across both VTO overlays, plus one data fix.

**Fitting-room accordion header (desktop + mobile)**
- Category label rendered in Times New Roman, regular (`fontWeight: 400`).
- Desktop label bumped 16px → 20px, with `letter-spacing: 0.04em`.
- Mobile label + inline product name carry the same serif/letter-spacing treatment, 16px (was 15px).

**Quick-view mobile product-details popover (`ProductSummaryRow`)**
- Category label now uses the per-category **singular** label (e.g. "Top") via `byName(...).label_singular ?? .label`, matching what the fitting-room accordion shows. The previous `groupForCategory(...).label` returned the plural group label ("Tops") and `StyleCategoryGroup` has no singular form.
- Category label + product name rendered in Times New Roman at 16px.

**Lighter body weights in the fit/size box (desktop only, both overlays)**
- Product title, "Select a size to see how it fits", item-fit text, and the rows inside `<ItemFitDetails>` drop to `fontWeight: 300`.
- Bold recommended-size line (weight 600) and the `<SizeSelector>` buttons are intentionally untouched.

**Inter loading**
- `src/style.css` now imports the variable-axis URL (`wght@100..900`) instead of the static `400;500;600;700` list, so any integer weight (e.g. 300) renders at the actual designed weight instead of falling back to the nearest pre-loaded face.

## Test plan
- [ ] Open the fitting-room overlay on desktop — accordion headers read as serif, larger; body text in the fit box reads visibly lighter than before.
- [ ] Mobile layout (resize or device emulation) — accordion header serif at 16px.
- [ ] Open quick-view on mobile (or narrow desktop) — `ProductSummaryRow` shows "Top" not "Tops"; both lines are serif at 16px.
- [ ] Quick-view desktop fit box — product title + body text lighter; recommended-size line still bold; size buttons unchanged.
- [ ] No layout regressions in either overlay; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)