### PR TITLE
VTO overlays: type/layout polish, gesture fixes, auto-rotate on add

### DIFF
--- a/src/components/avatar-frame-viewer.tsx
+++ b/src/components/avatar-frame-viewer.tsx
@@ -13,6 +13,10 @@ interface AvatarFrameViewerProps {
   imageContainerStyle: StyleProp
   imageStyle: StyleProp
   loadingT?: string
+  // Optional callback fired the moment the user manually moves the frame
+  // (chevron tap or drag). Used by parents that run useAutoRotate to halt
+  // an in-flight rotation as soon as the user takes control.
+  onUserInteract?: () => void
 }
 
 // AvatarFrameViewer renders a single avatar/VTO frame from `frameUrls` with
@@ -27,6 +31,7 @@ export function AvatarFrameViewer({
   imageContainerStyle,
   imageStyle,
   loadingT = 'quick-view.avatar_loading',
+  onUserInteract,
 }: AvatarFrameViewerProps) {
   const css = useCss((_theme) => ({
     imageContainer: {
@@ -66,26 +71,21 @@ export function AvatarFrameViewer({
     },
   }))
 
-  // Auto-rotate avatar on initial frame load
+  // Default to frame 0 when frames first arrive — otherwise the viewer
+  // would sit on the Loading state forever for callers that don't drive
+  // selectedFrameIndex. The auto-rotate animation lives in useAutoRotate
+  // on the parent (Avatar in quick-view, AvatarPane in fitting-room) —
+  // see use-auto-rotate.ts for why it's hosted up there.
   useEffect(() => {
-    if (!frameUrls || frameUrls.length === 0 || selectedFrameIndex != null) {
-      return
+    if (frameUrls && frameUrls.length > 0 && selectedFrameIndex == null) {
+      setSelectedFrameIndex(0)
     }
-    let currentFrameIndex = 0
-    setSelectedFrameIndex(currentFrameIndex)
-    const intervalId = setInterval(() => {
-      currentFrameIndex = (currentFrameIndex + 1) % frameUrls.length
-      setSelectedFrameIndex(currentFrameIndex)
-      if (currentFrameIndex === 0) {
-        clearInterval(intervalId)
-      }
-    }, 500)
-    return () => clearInterval(intervalId)
   }, [frameUrls, selectedFrameIndex, setSelectedFrameIndex])
 
   const { rotateLeft, rotateRight, handleMouseDragStart, handleTouchDragStart } = useFrameRotation(
     frameUrls,
     setSelectedFrameIndex,
+    onUserInteract,
   )
 
   if (!frameUrls || selectedFrameIndex == null) {

--- a/src/components/avatar-frame-viewer.tsx
+++ b/src/components/avatar-frame-viewer.tsx
@@ -35,6 +35,12 @@ export function AvatarFrameViewer({
     image: {
       objectFit: 'contain',
       cursor: 'grab',
+      // Reserve horizontal touch gestures for our rotation handler — the
+      // browser can still pan vertically natively. Without this, the
+      // browser may start consuming a horizontal swipe as a scroll/zoom
+      // before our touchmove listener can preventDefault, which produced
+      // the "janky first swipe" reports.
+      touchAction: 'pan-y',
     },
     chevronLeftContainer: {
       position: 'absolute',

--- a/src/components/avatar-frame-viewer.tsx
+++ b/src/components/avatar-frame-viewer.tsx
@@ -42,6 +42,8 @@ export function AvatarFrameViewer({
       left: '0',
       transform: 'translateY(-50%)',
       cursor: 'pointer',
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
     },
     chevronRightContainer: {
       position: 'absolute',
@@ -49,6 +51,8 @@ export function AvatarFrameViewer({
       right: '0',
       transform: 'translateY(-50%)',
       cursor: 'pointer',
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
     },
     chevronIcon: {
       width: '48px',
@@ -91,10 +95,14 @@ export function AvatarFrameViewer({
         onMouseDown={handleMouseDragStart}
         onTouchStart={handleTouchDragStart}
       />
-      <div css={css.chevronLeftContainer} onClick={rotateLeft}>
+      {/* onMouseDown preventDefault keeps rapid clicks from initiating a text
+          selection — otherwise the second/third click in a fast tap-tap-tap
+          starts dragging a selection that extends across nearby overlay text
+          (the avatar-control pill labels in the same VTO frame). */}
+      <div css={css.chevronLeftContainer} onMouseDown={(e) => e.preventDefault()} onClick={rotateLeft}>
         <ChevronLeftIcon css={css.chevronIcon} />
       </div>
-      <div css={css.chevronRightContainer} onClick={rotateRight}>
+      <div css={css.chevronRightContainer} onMouseDown={(e) => e.preventDefault()} onClick={rotateRight}>
         <ChevronRightIcon css={css.chevronIcon} />
       </div>
     </div>

--- a/src/components/avatar-frame-viewer.tsx
+++ b/src/components/avatar-frame-viewer.tsx
@@ -105,10 +105,22 @@ export function AvatarFrameViewer({
           selection — otherwise the second/third click in a fast tap-tap-tap
           starts dragging a selection that extends across nearby overlay text
           (the avatar-control pill labels in the same VTO frame). */}
-      <div css={css.chevronLeftContainer} onMouseDown={(e) => e.preventDefault()} onClick={rotateLeft}>
+      <div
+        role="button"
+        aria-label="Rotate left"
+        css={css.chevronLeftContainer}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={rotateLeft}
+      >
         <ChevronLeftIcon css={css.chevronIcon} />
       </div>
-      <div css={css.chevronRightContainer} onMouseDown={(e) => e.preventDefault()} onClick={rotateRight}>
+      <div
+        role="button"
+        aria-label="Rotate right"
+        css={css.chevronRightContainer}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={rotateRight}
+      >
         <ChevronRightIcon css={css.chevronIcon} />
       </div>
     </div>

--- a/src/components/overlays/fitting-room/avatar-controls.tsx
+++ b/src/components/overlays/fitting-room/avatar-controls.tsx
@@ -111,6 +111,11 @@ export function AvatarControls({
       // frame, which subpixel-shimmered. The max-width clip alone reveals
       // the label cleanly at full opacity.
       transition: 'max-width 500ms cubic-bezier(0.22, 1, 0.36, 1)',
+      // Belt-and-suspenders with pillBaseStyle on the parent — rapid clicks
+      // on the avatar's rotation chevrons can otherwise extend a triple-
+      // click selection into these labels.
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
     },
     pillLabelCollapsed: {
       maxWidth: 0,

--- a/src/components/overlays/fitting-room/avatar-pane.tsx
+++ b/src/components/overlays/fitting-room/avatar-pane.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { AvatarFrameViewer } from '@/components/avatar-frame-viewer'
 import { Loading } from '@/components/content/loading'
 import { TextT } from '@/components/text'
+import { useAutoRotate } from '@/components/use-auto-rotate'
 import { AVATAR_BOTTOM_BACKGROUND_URL } from '@/lib/asset'
 import { useCss } from '@/lib/theme'
 
@@ -22,6 +23,12 @@ interface AvatarPaneProps {
   // currently-displayed frame.
   selectedFrameIndex?: number | null
   setSelectedFrameIndex?: Dispatch<SetStateAction<number | null>>
+  // Bump this from the parent each time a new product is added to the
+  // outfit to trigger an auto-rotate animation. Undefined when dormant
+  // (bare-avatar baseline before the first product is added). Size/color
+  // changes — which replace frameUrls without bumping the trigger — are
+  // ignored. See use-auto-rotate.ts for the contract.
+  autoRotateTrigger?: number
 }
 
 // AvatarPane is the left-column avatar area on desktop and the background of
@@ -36,11 +43,17 @@ export function AvatarPane({
   mobileFullscreen,
   selectedFrameIndex: indexProp,
   setSelectedFrameIndex: setIndexProp,
+  autoRotateTrigger,
 }: AvatarPaneProps) {
   const [localFrameIndex, setLocalFrameIndex] = useState<number | null>(null)
   // Controlled when the caller supplies an index; otherwise self-managed.
   const selectedFrameIndex = indexProp !== undefined ? indexProp : localFrameIndex
   const setSelectedFrameIndex = setIndexProp ?? setLocalFrameIndex
+
+  // AvatarPane stays mounted across frameUrls null↔ready loading transitions
+  // (the inner viewer unmounts during the "Finding your perfect fit" loader),
+  // so the trigger-comparison ref inside this hook persists correctly.
+  const cancelAutoRotate = useAutoRotate(autoRotateTrigger, frameUrls, setSelectedFrameIndex)
 
   const css = useCss((theme) => ({
     container: {
@@ -112,6 +125,7 @@ export function AvatarPane({
         imageContainerStyle={css.frameContainer}
         imageStyle={css.frameImage}
         loadingT="quick-view.avatar_loading"
+        onUserInteract={cancelAutoRotate}
       />
     )
     if (mobileFullscreen) {

--- a/src/components/overlays/fitting-room/avatar-pane.tsx
+++ b/src/components/overlays/fitting-room/avatar-pane.tsx
@@ -53,7 +53,7 @@ export function AvatarPane({
   // AvatarPane stays mounted across frameUrls null↔ready loading transitions
   // (the inner viewer unmounts during the "Finding your perfect fit" loader),
   // so the trigger-comparison ref inside this hook persists correctly.
-  const cancelAutoRotate = useAutoRotate(autoRotateTrigger, frameUrls, setSelectedFrameIndex)
+  const cancelAutoRotate = useAutoRotate(autoRotateTrigger, frameUrls, selectedFrameIndex, setSelectedFrameIndex)
 
   const css = useCss((theme) => ({
     container: {

--- a/src/components/overlays/fitting-room/desktop-layout.tsx
+++ b/src/components/overlays/fitting-room/desktop-layout.tsx
@@ -37,6 +37,7 @@ interface DesktopLayoutProps {
   // The outfit has something to tuck into — computed in FittingRoomOverlay.
   canTuck: boolean
   frameUrls: string[] | null
+  autoRotateTrigger: number | undefined
   onSelectItem: (externalId: string) => void
   onRemoveItem: (externalId: string) => void
   onOpenAccordionItem: (externalId: string | null) => void
@@ -59,6 +60,7 @@ export function DesktopLayout({
   forceUntuck,
   canTuck,
   frameUrls,
+  autoRotateTrigger,
   onSelectItem,
   onRemoveItem,
   onOpenAccordionItem,
@@ -205,6 +207,7 @@ export function DesktopLayout({
           controls={controls}
           selectedFrameIndex={selectedFrameIndex}
           setSelectedFrameIndex={setSelectedFrameIndex}
+          autoRotateTrigger={autoRotateTrigger}
         />
       </div>
       {hasSelection ? (

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -71,6 +71,11 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
 
   const [topOffset, setTopOffset] = useState<number>(0)
   const [selectedExternalIds, setSelectedExternalIds] = useState<Set<string>>(() => new Set())
+  // Bumped each time a product is added to the outfit (in handleSelectItem's
+  // add branch). The AvatarPane → useAutoRotate hook plays one full rotation
+  // each time this number changes. Undefined while dormant so the bare-
+  // avatar baseline doesn't auto-rotate before any add has happened.
+  const [autoRotateTrigger, setAutoRotateTrigger] = useState<number | undefined>(undefined)
   const [openAccordionItemId, setOpenAccordionItemId] = useState<string | null>(null)
   const [detailMode, setDetailMode] = useState<DetailMode>('compact')
   const [forceUntuck, setForceUntuck] = useState<boolean>(false)
@@ -204,6 +209,11 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
         nextSelected.add(externalId)
         ensureSizeForItem(item)
         setLastAddedExternalId(externalId)
+        // Trigger a one-shot auto-rotation when the new product's VTO frames
+        // arrive (see useAutoRotate). Size/color changes don't bump this so
+        // they don't fire a rotation; remove + re-add does because each add
+        // increments.
+        setAutoRotateTrigger((n) => (n ?? 0) + 1)
         // Desktop: open accordion to the newly-added item. Mobile: stay in browse.
         if (!isMobileLayout) {
           setOpenAccordionItemId(externalId)
@@ -525,6 +535,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             forceUntuck={forceUntuck}
             canTuck={canTuck}
             frameUrls={frameUrls}
+            autoRotateTrigger={autoRotateTrigger}
             sheetSnap={sheetSnap}
             sheetTouchStart={sheetTouchStart}
             onSelectItem={handleSelectItem}
@@ -548,6 +559,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             forceUntuck={forceUntuck}
             canTuck={canTuck}
             frameUrls={frameUrls}
+            autoRotateTrigger={autoRotateTrigger}
             onSelectItem={handleSelectItem}
             onRemoveItem={handleRemoveItem}
             onOpenAccordionItem={setOpenAccordionItemId}

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -348,15 +348,20 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
   }, [openAccordionItemId, selectedExternalIds])
 
   // Preselect the current PDP product when the overlay was opened from the
-  // "Try It On" CTA. The CTA adds the product to the fitting room asynchronously,
-  // so wait until it resolves into `resolved.items`, then run the normal
-  // selection path (auto-size-rec, accordion open) exactly once.
+  // "Try It On" CTA. The CTA adds the product to the fitting room
+  // asynchronously, so wait until both the storage entry AND its backing data
+  // (merchantProduct + loadedProduct) have landed before running the normal
+  // selection path. Without the load-complete gate, ensureSizeForItem fires
+  // too early (buildVtoProductDataFromResolved returns null without
+  // loadedProduct), leaves the new item's CSA as null, and the outfit
+  // builder silently drops it — producing a bare avatar with no VTO.
   const preselectAppliedRef = useRef(false)
   useEffect(() => {
     if (preselectAppliedRef.current || !preselectExternalId) {
       return
     }
-    if (!resolved.items.some((i) => i.externalId === preselectExternalId)) {
+    const item = resolved.items.find((i) => i.externalId === preselectExternalId)
+    if (!item || !item.merchantProduct || !item.loadedProduct) {
       return
     }
     preselectAppliedRef.current = true

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -66,6 +66,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
   const closeOverlay = useMainStore((state) => state.closeOverlay)
   const openOverlay = useMainStore((state) => state.openOverlay)
   const updateFittingRoomItem = useMainStore((state) => state.updateFittingRoomItem)
+  const removeFromFittingRoom = useMainStore((state) => state.removeFromFittingRoom)
   const resolved = useResolvedFittingRoom()
 
   const [topOffset, setTopOffset] = useState<number>(0)
@@ -308,8 +309,12 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
       if (openAccordionItemId === externalId) {
         setOpenAccordionItemId(null)
       }
+      // Drop the item from persisted storage so the rail card disappears
+      // and the removal survives an overlay reopen / page reload. Without
+      // this the X only deselected the item within the current overlay.
+      removeFromFittingRoom(externalId)
     },
-    [openAccordionItemId],
+    [openAccordionItemId, removeFromFittingRoom],
   )
 
   const handleTryItOn = useCallback(() => {

--- a/src/components/overlays/fitting-room/mobile-layout.tsx
+++ b/src/components/overlays/fitting-room/mobile-layout.tsx
@@ -31,6 +31,7 @@ interface MobileLayoutProps {
   // The outfit has something to tuck into — computed in FittingRoomOverlay.
   canTuck: boolean
   frameUrls: string[] | null
+  autoRotateTrigger: number | undefined
   sheetSnap: SheetSnap
   sheetTouchStart: (e: React.TouchEvent<HTMLElement>) => void
   onSelectItem: (externalId: string) => void
@@ -58,6 +59,7 @@ export function MobileLayout({
   forceUntuck,
   canTuck,
   frameUrls,
+  autoRotateTrigger,
   sheetSnap,
   sheetTouchStart,
   onSelectItem,
@@ -91,6 +93,7 @@ export function MobileLayout({
       forceUntuck={forceUntuck}
       canTuck={canTuck}
       frameUrls={frameUrls}
+      autoRotateTrigger={autoRotateTrigger}
       sheetSnap={sheetSnap}
       sheetTouchStart={sheetTouchStart}
       onBackToBrowse={onBackToBrowse}
@@ -239,6 +242,7 @@ function TryOnView({
   forceUntuck,
   canTuck,
   frameUrls,
+  autoRotateTrigger,
   sheetSnap,
   sheetTouchStart,
   onBackToBrowse,
@@ -255,6 +259,7 @@ function TryOnView({
   forceUntuck: boolean
   canTuck: boolean
   frameUrls: string[] | null
+  autoRotateTrigger: number | undefined
   sheetSnap: SheetSnap
   sheetTouchStart: (e: React.TouchEvent<HTMLElement>) => void
   onBackToBrowse: () => void
@@ -364,6 +369,7 @@ function TryOnView({
       <AvatarPane
         hasSelection={selectedItems.length > 0}
         frameUrls={frameUrls}
+        autoRotateTrigger={autoRotateTrigger}
         mobileFullscreen
         controls={<MobileTuckControl canTuck={canTuck} forceUntuck={forceUntuck} onToggleUntuck={onToggleUntuck} />}
       />

--- a/src/components/overlays/fitting-room/product-card.tsx
+++ b/src/components/overlays/fitting-room/product-card.tsx
@@ -103,11 +103,18 @@ export function ProductCard({ item, availability, onClick, onRemove }: ProductCa
   }
 
   const name = item.merchantProduct?.productName ?? item.externalId
-  const imageUrl = item.merchantProduct?.imageUrl ?? null
 
-  // Pick a price from variants if available — first variant's price is fine
-  // for the rail; the accordion shows the precise selected-size price.
-  const price = item.merchantProduct?.variants[0]?.priceFormatted ?? null
+  // Look up the variant that matches the stored color (and size when known).
+  // Used for both the card image and the price so a multi-colour product
+  // shows the right colour swatch the shopper picked, not the merchant's
+  // default. Falls back through: variant.imageUrl → product.imageUrl, and
+  // variant.priceFormatted → variants[0].priceFormatted, so single-colour
+  // products and items without per-variant images still render.
+  const selectedVariant = item.merchantProduct?.variants.find(
+    (v) => v.color === item.storage.color && (!item.storage.size || v.size === item.storage.size),
+  )
+  const imageUrl = selectedVariant?.imageUrl ?? item.merchantProduct?.imageUrl ?? null
+  const price = selectedVariant?.priceFormatted ?? item.merchantProduct?.variants[0]?.priceFormatted ?? null
 
   return (
     <div

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -47,6 +47,19 @@ const AVATAR_IMAGE_ASPECT_RATIO = 2 / 3 // width:height
 const AVATAR_GUTTER_HEIGHT_PX = 100
 const CONTENT_AREA_WIDTH_PX = 550
 
+// Rotation slider below the desktop avatar. Hidden 2026-05-24 — fitting-room
+// has no equivalent and the drag-on-image gesture already handles rotation.
+// Flip to true to restore the slider; the surrounding gutter, styles, and
+// frame-index state all stay wired up for that.
+const SHOW_ROTATION_SLIDER = false
+
+// On desktop, image height = screen height − gutter (and width is derived from
+// that), so collapsing the gutter when the slider is hidden lets the avatar
+// fill the available height. The mobile branch keeps `AVATAR_GUTTER_HEIGHT_PX`
+// regardless — its gutter exists to leave room for the collapsed product-
+// details popover, not for the slider.
+const DESKTOP_AVATAR_GUTTER_HEIGHT_PX = SHOW_ROTATION_SLIDER ? AVATAR_GUTTER_HEIGHT_PX : 0
+
 const logger = getLogger('overlays/quick-view')
 
 export default function QuickViewOverlay() {
@@ -1129,8 +1142,11 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
     },
     zoomPill: {
       position: 'absolute',
-      // Bottom-right of the avatar image, clear of the slider gutter below it.
-      bottom: `${AVATAR_GUTTER_HEIGHT_PX + 16}px`,
+      // Bottom-right of the avatar image, 16px above the image's bottom edge.
+      // When the rotation slider is on, that's also `clear of the gutter` —
+      // when the slider is hidden, the gutter collapses to 0 and the 16px
+      // offset alone keeps the pill inset from the image's true bottom.
+      bottom: `${DESKTOP_AVATAR_GUTTER_HEIGHT_PX + 16}px`,
       right: '16px',
       display: 'inline-flex',
       alignItems: 'center',
@@ -1222,7 +1238,7 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
         }
       } else {
         const screenHeightPx = window.innerHeight
-        const bottomContainerHeightPx = AVATAR_GUTTER_HEIGHT_PX
+        const bottomContainerHeightPx = DESKTOP_AVATAR_GUTTER_HEIGHT_PX
         const imageHeightPx = screenHeightPx - bottomContainerHeightPx
         const imageWidthPx = Math.floor(imageHeightPx * AVATAR_IMAGE_ASPECT_RATIO)
         const modalWidthPx = imageWidthPx + CONTENT_AREA_WIDTH_PX
@@ -1288,7 +1304,7 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
           onClose={() => setZoomOpen(false)}
         />
       ) : null}
-      {frameUrls && selectedFrameIndex != null ? (
+      {frameUrls && selectedFrameIndex != null && (isMobileLayout || SHOW_ROTATION_SLIDER) ? (
         <div css={css.bottomContainer} style={layoutData.bottomContainerStyle}>
           {isMobileLayout ? (
             <>&nbsp;</>

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -951,7 +951,7 @@ function DesktopLayout({
     productNameContainer: {},
     productNameText: {
       fontFamily: "'Inter', sans-serif",
-      fontSize: '32px',
+      fontSize: '24px',
       fontWeight: 300,
     },
     priceContainer: {

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -71,6 +71,8 @@ export default function QuickViewOverlay() {
   const deviceLayout = useMainStore((state) => state.deviceLayout)
   const openOverlay = useMainStore((state) => state.openOverlay)
   const closeOverlay = useMainStore((state) => state.closeOverlay)
+  const updateFittingRoomItem = useMainStore((state) => state.updateFittingRoomItem)
+  const fittingRoomItems = useMainStore((state) => state.fittingRoom)
   const [vtoProductData, setVtoProductData] = useState<VtoProductData | false | null>(null)
   const [selectedSizeLabel, setSelectedSizeLabel] = useState<string | null>(null)
   const [selectedColorLabel, setSelectedColorLabel] = useState<string | null>(null)
@@ -314,6 +316,36 @@ export default function QuickViewOverlay() {
       logger.logError('Error during logout:', { error })
     })
   }, [closeOverlay])
+  // Wrap the color setter so a color change inside quick-view also persists
+  // to the fitting-room storage entry for the current product (when it's
+  // already in the room). Without this, changing color here and then opening
+  // the fitting-room overlay later would show the *previously stored* color,
+  // not what the shopper actually picked — and the rail card would render
+  // the wrong variant image.
+  const handleChangeColor = useCallback(
+    (newColorLabel: string | null) => {
+      setSelectedColorLabel(newColorLabel)
+      const currentProduct = getStaticData().currentProduct
+      if (!currentProduct) {
+        return
+      }
+      const inRoom = fittingRoomItems.some((item) => item.externalId === currentProduct.externalId)
+      if (!inRoom || !vtoProductData || !selectedSizeLabel) {
+        return
+      }
+      const sizeRec = vtoProductData.sizes.find((s) => s.sizeLabel === selectedSizeLabel)
+      const csa = sizeRec?.colors.find((c) => c.colorLabel === newColorLabel)
+      if (!csa) {
+        return
+      }
+      updateFittingRoomItem(currentProduct.externalId, {
+        colorwaySizeAssetId: csa.colorwaySizeAssetId,
+        size: selectedSizeLabel,
+        color: csa.colorLabel,
+      })
+    },
+    [fittingRoomItems, selectedSizeLabel, updateFittingRoomItem, vtoProductData],
+  )
   const handleAddToCartClick = useCallback(async () => {
     try {
       if (!selectedSizeLabel) {
@@ -367,7 +399,7 @@ export default function QuickViewOverlay() {
         frameUrls={frameUrls}
         setModalStyle={setModalStyle}
         onClose={closeOverlay}
-        onChangeColor={setSelectedColorLabel}
+        onChangeColor={handleChangeColor}
         onChangeSize={setSelectedSizeLabel}
         onAddToCart={handleAddToCartClick}
         onSignOut={handleSignOutClick}

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -1167,7 +1167,7 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
   // Quick-view is a single-product VTO — only "add" is the initial load, so a
   // constant trigger fires the auto-rotate exactly once per Avatar mount and
   // never re-fires (size/color changes don't bump it).
-  const cancelAutoRotate = useAutoRotate(1, frameUrls, setSelectedFrameIndex)
+  const cancelAutoRotate = useAutoRotate(1, frameUrls, selectedFrameIndex, setSelectedFrameIndex)
   const css = useCss((theme) => ({
     topContainer: {
       flex: 'none',

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -676,13 +676,23 @@ interface MobileContentProps {
   onSignOut: () => void
 }
 
-function MobileContentCollapsed({ loadedProductData, selectedSizeLabel, onChangeSize }: MobileContentProps) {
+function MobileContentCollapsed({
+  loadedProductData,
+  availableColorLabels,
+  selectedColorLabel,
+  selectedSizeLabel,
+  onChangeColor,
+  onChangeSize,
+}: MobileContentProps) {
   const css = useCss((_theme) => ({
     selectSizeLabelContainer: {
       marginTop: '8px',
     },
     selectSizeLabelText: {},
     sizeSelectorContainer: {
+      marginTop: '8px',
+    },
+    colorSelectorContainer: {
       marginTop: '8px',
     },
   }))
@@ -698,14 +708,24 @@ function MobileContentCollapsed({ loadedProductData, selectedSizeLabel, onChange
           onChangeSize={onChangeSize}
         />
       </div>
+      <div css={css.colorSelectorContainer}>
+        <ColorSelector
+          availableColorLabels={availableColorLabels}
+          selectedColorLabel={selectedColorLabel}
+          onChangeColor={onChangeColor}
+        />
+      </div>
     </>
   )
 }
 
 function MobileContentExpanded({
   loadedProductData,
+  availableColorLabels,
+  selectedColorLabel,
   selectedSizeLabel,
   onChangeContentView,
+  onChangeColor,
   onChangeSize,
   onAddToCart,
 }: MobileContentProps) {
@@ -715,6 +735,9 @@ function MobileContentExpanded({
     },
     selectSizeLabelText: {},
     sizeSelectorContainer: {
+      marginTop: '8px',
+    },
+    colorSelectorContainer: {
       marginTop: '8px',
     },
     itemFitTextContainer: {
@@ -755,6 +778,13 @@ function MobileContentExpanded({
           loadedProductData={loadedProductData}
           selectedSizeLabel={selectedSizeLabel}
           onChangeSize={onChangeSize}
+        />
+      </div>
+      <div css={css.colorSelectorContainer}>
+        <ColorSelector
+          availableColorLabels={availableColorLabels}
+          selectedColorLabel={selectedColorLabel}
+          onChangeColor={onChangeColor}
         />
       </div>
       <div css={css.itemFitTextContainer}>

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -1190,6 +1190,10 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
       letterSpacing: '0.5px',
       textTransform: 'uppercase',
       cursor: 'pointer',
+      // Rapid clicks on the rotation chevrons can otherwise spill a triple-
+      // click selection into this label.
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
       zIndex: 2,
     },
     zoomPillIcon: {

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AddToCartButton } from '@/components/add-to-cart-button'
 import { AvatarFrameViewer } from '@/components/avatar-frame-viewer'
+import { useAutoRotate } from '@/components/use-auto-rotate'
 import { Button } from '@/components/button'
 import { ColorSelector } from '@/components/color-selector'
 import { FitChart } from '@/components/content/fit-chart'
@@ -1163,6 +1164,10 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
   })
   const [selectedFrameIndex, setSelectedFrameIndex] = useState<number | null>(null)
   const [zoomOpen, setZoomOpen] = useState<boolean>(false)
+  // Quick-view is a single-product VTO — only "add" is the initial load, so a
+  // constant trigger fires the auto-rotate exactly once per Avatar mount and
+  // never re-fires (size/color changes don't bump it).
+  const cancelAutoRotate = useAutoRotate(1, frameUrls, setSelectedFrameIndex)
   const css = useCss((theme) => ({
     topContainer: {
       flex: 'none',
@@ -1323,6 +1328,7 @@ function Avatar({ frameUrls, setModalStyle }: AvatarProps) {
         imageContainerStyle={layoutData.imageContainerStyle}
         imageStyle={layoutData.imageStyle}
         loadingT="quick-view.avatar_loading"
+        onUserInteract={cancelAutoRotate}
       />
       {isReady && !isMobileLayout ? (
         <Button variant="base" css={css.zoomPill} onClick={() => setZoomOpen(true)}>

--- a/src/components/use-auto-rotate.ts
+++ b/src/components/use-auto-rotate.ts
@@ -1,0 +1,94 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+
+const AUTO_ROTATE_TICK_MS = 500
+
+// useAutoRotate plays one full rotation through `frameUrls` (0 → length-1 → 0)
+// each time `trigger` changes from its previous fired value AND frames are
+// present. The intended use is "play a fresh rotation when a new product is
+// added to the VTO outfit" — parents bump `trigger` on that event only, so
+// size/color changes (which replace frameUrls but don't bump the trigger)
+// are ignored.
+//
+// `trigger` is `undefined` when auto-rotate is dormant (e.g. the fitting-room
+// bare-avatar state before any product has been added). Bumping to any number
+// from undefined counts as a change and fires once; subsequent re-fires
+// require the number to differ from the last-fired value.
+//
+// Hosted on the *parent* of AvatarFrameViewer (Avatar in quick-view,
+// AvatarPane in fitting-room) — the viewer unmounts during loading
+// transitions in fitting-room, which would reset any ref state living inside
+// it and cause false fires on remount.
+//
+// Returns `cancelAutoRotate` — call it from any code path that lets the user
+// manually move the frame (chevron taps, drag) to halt the in-flight
+// rotation. The previous "detect cancellation by comparing prev state inside
+// the setter" approach was broken under React 18's deferred-updater batching:
+// the updater runs asynchronously, so side-effects mutated inside it weren't
+// visible to code outside the setter, and the very first tick saw stale
+// `nextFrameIndex = 0` and immediately cleared the interval thinking it had
+// wrapped. Explicit cancellation removes the race entirely.
+export function useAutoRotate(
+  trigger: number | undefined,
+  frameUrls: string[] | null | undefined,
+  setSelectedFrameIndex: Dispatch<SetStateAction<number | null>>,
+): () => void {
+  const lastFiredRef = useRef<number | undefined>(undefined)
+  // Mutable handle to the active interval so the cancel callback (and the
+  // effect's cleanup) can stop it even though they live outside the effect's
+  // closure of any specific run.
+  const intervalIdRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const cancelAutoRotate = useCallback(() => {
+    if (intervalIdRef.current !== null) {
+      clearInterval(intervalIdRef.current)
+      intervalIdRef.current = null
+    }
+  }, [])
+
+  // Depend on the frame *count* rather than the frameUrls array reference.
+  // Background prefetch landings update an upstream `framesByKey` map which
+  // rebuilds `framesForOutfit` (and therefore frameUrls's reference) every
+  // few hundred ms; depending on the reference would re-run this effect on
+  // each landing and kill the in-progress rotation. Length is stable for the
+  // same outfit, which is the only signal we need here.
+  const frameCount = frameUrls?.length ?? 0
+  useEffect(() => {
+    if (trigger === undefined) {
+      return
+    }
+    if (frameCount === 0) {
+      return
+    }
+    if (trigger === lastFiredRef.current) {
+      return
+    }
+    // Don't record `lastFiredRef` until the interval actually fires its
+    // first tick. React Strict Mode (dev) runs every effect twice on mount —
+    // run → cleanup → run — and the cleanup happens synchronously before any
+    // 500ms tick. If we recorded the trigger eagerly here, the second run
+    // would see `trigger === lastFiredRef` and early-return, leaving the
+    // rotation un-played. Recording on the first tick means a never-fired
+    // interval (Strict Mode's first run) leaves the ref unchanged, so the
+    // second run fires fresh and *that's* the interval that survives.
+    let currentFrameIndex = 0
+    let didFirstTick = false
+    setSelectedFrameIndex(0)
+    intervalIdRef.current = setInterval(() => {
+      if (!didFirstTick) {
+        didFirstTick = true
+        lastFiredRef.current = trigger
+      }
+      const nextFrameIndex = (currentFrameIndex + 1) % frameCount
+      currentFrameIndex = nextFrameIndex
+      setSelectedFrameIndex(nextFrameIndex)
+      if (nextFrameIndex === 0) {
+        // Completed a full cycle.
+        cancelAutoRotate()
+      }
+    }, AUTO_ROTATE_TICK_MS)
+    return cancelAutoRotate
+  }, [trigger, frameCount, setSelectedFrameIndex, cancelAutoRotate])
+
+  return cancelAutoRotate
+}

--- a/src/components/use-auto-rotate.ts
+++ b/src/components/use-auto-rotate.ts
@@ -7,12 +7,15 @@ import { useCallback, useEffect, useRef } from 'react'
 // time (and shorter frame sets just feel less granular).
 const AUTO_ROTATE_DURATION_MS = 4000
 
-// useAutoRotate plays one full rotation through `frameUrls` (0 → length-1 → 0)
-// each time `trigger` changes from its previous fired value AND frames are
-// present. The intended use is "play a fresh rotation when a new product is
-// added to the VTO outfit" — parents bump `trigger` on that event only, so
-// size/color changes (which replace frameUrls but don't bump the trigger)
-// are ignored.
+// useAutoRotate plays one full rotation through `frameUrls` each time
+// `trigger` changes from its previous fired value AND frames are present.
+// The rotation starts AND ends at whichever frame index is currently
+// selected at the moment trigger advances — so a shopper who rotated the
+// avatar to a particular angle and then adds another product sees the new
+// outfit spin past that same angle and settle back on it. The intended use
+// is "play a fresh rotation when a new product is added to the VTO outfit"
+// — parents bump `trigger` on that event only, so size/color changes
+// (which replace frameUrls but don't bump the trigger) are ignored.
 //
 // `trigger` is `undefined` when auto-rotate is dormant (e.g. the fitting-room
 // bare-avatar state before any product has been added). Bumping to any number
@@ -35,6 +38,7 @@ const AUTO_ROTATE_DURATION_MS = 4000
 export function useAutoRotate(
   trigger: number | undefined,
   frameUrls: string[] | null | undefined,
+  selectedFrameIndex: number | null,
   setSelectedFrameIndex: Dispatch<SetStateAction<number | null>>,
 ): () => void {
   const lastFiredRef = useRef<number | undefined>(undefined)
@@ -42,6 +46,15 @@ export function useAutoRotate(
   // effect's cleanup) can stop it even though they live outside the effect's
   // closure of any specific run.
   const intervalIdRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Mirror selectedFrameIndex into a ref so the rotation effect can capture
+  // the "currently displayed frame" at fire time without including the index
+  // in the effect's dep array — which would tear down and rebuild the
+  // interval every single tick (the rotation calls setSelectedFrameIndex on
+  // each tick, so the value changes ~every 444 ms during play).
+  const indexRef = useRef<number | null>(selectedFrameIndex)
+  useEffect(() => {
+    indexRef.current = selectedFrameIndex
+  }, [selectedFrameIndex])
 
   const cancelAutoRotate = useCallback(() => {
     if (intervalIdRef.current !== null) {
@@ -70,15 +83,18 @@ export function useAutoRotate(
     // Don't record `lastFiredRef` until the interval actually fires its
     // first tick. React Strict Mode (dev) runs every effect twice on mount —
     // run → cleanup → run — and the cleanup happens synchronously before any
-    // 500ms tick. If we recorded the trigger eagerly here, the second run
-    // would see `trigger === lastFiredRef` and early-return, leaving the
-    // rotation un-played. Recording on the first tick means a never-fired
-    // interval (Strict Mode's first run) leaves the ref unchanged, so the
-    // second run fires fresh and *that's* the interval that survives.
+    // tick. If we recorded the trigger eagerly here, the second run would
+    // see `trigger === lastFiredRef` and early-return, leaving the rotation
+    // un-played. Recording on the first tick means a never-fired interval
+    // (Strict Mode's first run) leaves the ref unchanged, so the second run
+    // fires fresh and *that's* the interval that survives.
     const tickMs = Math.round(AUTO_ROTATE_DURATION_MS / frameCount)
-    let currentFrameIndex = 0
+    // Start (and stop) at whichever frame is currently displayed. Clamped to
+    // frameCount in case the new outfit has fewer frames than the previous
+    // selection — otherwise the stop condition could never match.
+    const startFrameIndex = (indexRef.current ?? 0) % frameCount
+    let currentFrameIndex = startFrameIndex
     let didFirstTick = false
-    setSelectedFrameIndex(0)
     intervalIdRef.current = setInterval(() => {
       if (!didFirstTick) {
         didFirstTick = true
@@ -87,8 +103,8 @@ export function useAutoRotate(
       const nextFrameIndex = (currentFrameIndex + 1) % frameCount
       currentFrameIndex = nextFrameIndex
       setSelectedFrameIndex(nextFrameIndex)
-      if (nextFrameIndex === 0) {
-        // Completed a full cycle.
+      if (nextFrameIndex === startFrameIndex) {
+        // Completed a full cycle and settled back on the start frame.
         cancelAutoRotate()
       }
     }, tickMs)

--- a/src/components/use-auto-rotate.ts
+++ b/src/components/use-auto-rotate.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef } from 'react'
 // renderer returns. Per-frame tick is derived as duration / frameCount, so a
 // 6-frame product and a 24-frame product both complete in the same wall-clock
 // time (and shorter frame sets just feel less granular).
-const AUTO_ROTATE_DURATION_MS = 6000
+const AUTO_ROTATE_DURATION_MS = 4000
 
 // useAutoRotate plays one full rotation through `frameUrls` (0 → length-1 → 0)
 // each time `trigger` changes from its previous fired value AND frames are

--- a/src/components/use-auto-rotate.ts
+++ b/src/components/use-auto-rotate.ts
@@ -1,7 +1,11 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef } from 'react'
 
-const AUTO_ROTATE_TICK_MS = 500
+// Total time for one full rotation, regardless of how many frames the VTO
+// renderer returns. Per-frame tick is derived as duration / frameCount, so a
+// 6-frame product and a 24-frame product both complete in the same wall-clock
+// time (and shorter frame sets just feel less granular).
+const AUTO_ROTATE_DURATION_MS = 6000
 
 // useAutoRotate plays one full rotation through `frameUrls` (0 → length-1 → 0)
 // each time `trigger` changes from its previous fired value AND frames are
@@ -71,6 +75,7 @@ export function useAutoRotate(
     // rotation un-played. Recording on the first tick means a never-fired
     // interval (Strict Mode's first run) leaves the ref unchanged, so the
     // second run fires fresh and *that's* the interval that survives.
+    const tickMs = Math.round(AUTO_ROTATE_DURATION_MS / frameCount)
     let currentFrameIndex = 0
     let didFirstTick = false
     setSelectedFrameIndex(0)
@@ -86,7 +91,7 @@ export function useAutoRotate(
         // Completed a full cycle.
         cancelAutoRotate()
       }
-    }, AUTO_ROTATE_TICK_MS)
+    }, tickMs)
     return cancelAutoRotate
   }, [trigger, frameCount, setSelectedFrameIndex, cancelAutoRotate])
 

--- a/src/components/use-frame-rotation.ts
+++ b/src/components/use-frame-rotation.ts
@@ -30,29 +30,38 @@ export function applyDragSteps(deltaX: number, rotateLeft: () => void, rotateRig
 // frame carousel (avatar frame viewer, zoom modal). The caller owns the
 // selected-index state; this hook only steps it. rotateLeft/rotateRight wrap
 // around and no-op while the index is still null (frames not ready).
+//
+// `onUserInteract` (optional) is called whenever a user-driven action (chevron
+// tap, drag start, drag step) advances the frame. Used by the AvatarFrameViewer
+// surface to cancel an in-flight auto-rotate animation as soon as the user
+// takes manual control. Pure rotateLeft/rotateRight callers (e.g. zoom modal
+// chevrons) can omit it.
 export function useFrameRotation(
   frameUrls: string[] | null,
   setSelectedFrameIndex: Dispatch<SetStateAction<number | null>>,
+  onUserInteract?: () => void,
 ) {
   const frameCount = frameUrls?.length ?? 0
 
   const rotateLeft = useCallback(() => {
+    onUserInteract?.()
     setSelectedFrameIndex((prev) => {
       if (prev == null || frameCount === 0) {
         return prev
       }
       return prev === 0 ? frameCount - 1 : prev - 1
     })
-  }, [frameCount, setSelectedFrameIndex])
+  }, [frameCount, onUserInteract, setSelectedFrameIndex])
 
   const rotateRight = useCallback(() => {
+    onUserInteract?.()
     setSelectedFrameIndex((prev) => {
       if (prev == null || frameCount === 0) {
         return prev
       }
       return prev === frameCount - 1 ? 0 : prev + 1
     })
-  }, [frameCount, setSelectedFrameIndex])
+  }, [frameCount, onUserInteract, setSelectedFrameIndex])
 
   const handleMouseDragStart = useCallback(
     (e: ReactMouseEvent) => {

--- a/src/components/use-frame-rotation.ts
+++ b/src/components/use-frame-rotation.ts
@@ -12,8 +12,9 @@ const AXIS_LOCK_PX = 8
 // has earned and returns how many pixels were consumed. The caller advances
 // its `startX` by the returned amount so leftover sub-step travel rolls over
 // into the next move event. This is the multi-step fix: a fast swipe of N×
-// DRAG_STEP_PX in a single move event rotates N frames, not 1.
-function applyDragSteps(deltaX: number, rotateLeft: () => void, rotateRight: () => void): number {
+// DRAG_STEP_PX in a single move event rotates N frames, not 1. Exported so
+// the zoom modal's own axis-locking drag handler uses the same step size.
+export function applyDragSteps(deltaX: number, rotateLeft: () => void, rotateRight: () => void): number {
   const steps = Math.floor(Math.abs(deltaX) / DRAG_STEP_PX)
   if (steps === 0) {
     return 0

--- a/src/components/use-frame-rotation.ts
+++ b/src/components/use-frame-rotation.ts
@@ -3,6 +3,27 @@ import { useCallback } from 'react'
 
 // Pointer pixels of horizontal drag per one frame of rotation.
 const DRAG_STEP_PX = 50
+// Pointer pixels of travel before a touch drag commits to either a horizontal
+// (rotation) or vertical (scroll) gesture. Also acts as a drag-vs-tap
+// threshold: stray finger jitter below this never starts firing rotations.
+const AXIS_LOCK_PX = 8
+
+// applyDragSteps fires as many rotation steps as the total horizontal travel
+// has earned and returns how many pixels were consumed. The caller advances
+// its `startX` by the returned amount so leftover sub-step travel rolls over
+// into the next move event. This is the multi-step fix: a fast swipe of N×
+// DRAG_STEP_PX in a single move event rotates N frames, not 1.
+function applyDragSteps(deltaX: number, rotateLeft: () => void, rotateRight: () => void): number {
+  const steps = Math.floor(Math.abs(deltaX) / DRAG_STEP_PX)
+  if (steps === 0) {
+    return 0
+  }
+  const fn = deltaX > 0 ? rotateRight : rotateLeft
+  for (let i = 0; i < steps; i++) {
+    fn()
+  }
+  return (deltaX > 0 ? 1 : -1) * steps * DRAG_STEP_PX
+}
 
 // useFrameRotation produces the rotate actions and pointer-drag handlers for a
 // frame carousel (avatar frame viewer, zoom modal). The caller owns the
@@ -37,15 +58,7 @@ export function useFrameRotation(
       e.preventDefault()
       let startX = e.clientX
       const onMove = (move: MouseEvent) => {
-        const deltaX = move.clientX - startX
-        if (Math.abs(deltaX) >= DRAG_STEP_PX) {
-          if (deltaX > 0) {
-            rotateRight()
-          } else {
-            rotateLeft()
-          }
-          startX = move.clientX
-        }
+        startX += applyDragSteps(move.clientX - startX, rotateLeft, rotateRight)
       }
       const onUp = () => {
         window.removeEventListener('mousemove', onMove)
@@ -57,27 +70,53 @@ export function useFrameRotation(
     [rotateLeft, rotateRight],
   )
 
+  // Touch drag with an axis lock: after AXIS_LOCK_PX of travel, commit to
+  // either *rotation* (horizontal-dominant) or *scroll* (vertical-dominant)
+  // for the rest of the gesture. Horizontal rotation calls preventDefault on
+  // each move so the page doesn't try to pan-x alongside it. The vertical
+  // branch deliberately does NOT preventDefault so native vertical scrolling
+  // keeps working. The companion CSS `touch-action: pan-y` on the avatar img
+  // tells the browser the same thing up-front so it doesn't claim horizontal
+  // gestures before our handler can react. Also note: `e.preventDefault()`
+  // on the React touchstart synthetic event is intentionally NOT called —
+  // React attaches touchstart as passive (>= v17) so that call is a no-op.
+  // The `{ passive: false }` on touchmove below is what actually lets the
+  // browser respect preventDefault inside the move handler.
   const handleTouchDragStart = useCallback(
     (e: ReactTouchEvent) => {
-      e.preventDefault()
       let startX = e.touches[0].clientX
+      const startY = e.touches[0].clientY
+      let mode: 'unknown' | 'horizontal' | 'vertical' = 'unknown'
+
       const onMove = (move: TouchEvent) => {
-        const deltaX = move.touches[0].clientX - startX
-        if (Math.abs(deltaX) >= DRAG_STEP_PX) {
-          if (deltaX > 0) {
-            rotateRight()
-          } else {
-            rotateLeft()
+        const currentX = move.touches[0].clientX
+        const currentY = move.touches[0].clientY
+        if (mode === 'unknown') {
+          const absDx = Math.abs(currentX - startX)
+          const absDy = Math.abs(currentY - startY)
+          if (absDx < AXIS_LOCK_PX && absDy < AXIS_LOCK_PX) {
+            return
           }
-          startX = move.touches[0].clientX
+          mode = absDx >= absDy ? 'horizontal' : 'vertical'
+          // Reset startX to the lock-decision point so the AXIS_LOCK_PX
+          // already travelled doesn't count toward the first rotation
+          // (which would feel like a jump at the start of the drag).
+          startX = currentX
         }
+        if (mode !== 'horizontal') {
+          return
+        }
+        move.preventDefault()
+        startX += applyDragSteps(currentX - startX, rotateLeft, rotateRight)
       }
       const onEnd = () => {
         window.removeEventListener('touchmove', onMove)
         window.removeEventListener('touchend', onEnd)
+        window.removeEventListener('touchcancel', onEnd)
       }
-      window.addEventListener('touchmove', onMove)
+      window.addEventListener('touchmove', onMove, { passive: false })
       window.addEventListener('touchend', onEnd)
+      window.addEventListener('touchcancel', onEnd)
     },
     [rotateLeft, rotateRight],
   )

--- a/src/components/zoom-modal.tsx
+++ b/src/components/zoom-modal.tsx
@@ -1,15 +1,13 @@
 import type { Dispatch, MouseEvent as ReactMouseEvent, SetStateAction } from 'react'
 import { useCallback, useEffect, useRef } from 'react'
-import { useFrameRotation } from '@/components/use-frame-rotation'
+import { applyDragSteps, useFrameRotation } from '@/components/use-frame-rotation'
 import { ChevronLeftIcon, ChevronRightIcon } from '@/lib/asset'
 import { useCss } from '@/lib/theme'
 
-// Pointer-pixel thresholds for the zoom modal's axis-locking image drag.
-// AXIS_LOCK_PX: how far the pointer moves before committing to scroll-or-rotate.
-// ROTATE_STEP_PX: pointer-px of horizontal travel per frame of rotation
-// (mirrors DRAG_STEP_PX in use-frame-rotation so the feel matches).
+// How far the pointer moves before the axis-lock commits to scroll-or-rotate.
+// The horizontal step size is owned by applyDragSteps in use-frame-rotation
+// so the rotation feel matches the non-zoomed avatar.
 const AXIS_LOCK_PX = 8
-const ROTATE_STEP_PX = 50
 
 interface ZoomModalProps {
   frameUrls: string[]
@@ -79,15 +77,7 @@ export function ZoomModal({ frameUrls, selectedFrameIndex, setSelectedFrameIndex
           // decreases as deltaY grows.
           scrollArea.scrollTop = startScrollTop - deltaY
         } else if (mode === 'rotate') {
-          const rotateDelta = move.clientX - lastRotateX
-          if (Math.abs(rotateDelta) >= ROTATE_STEP_PX) {
-            if (rotateDelta > 0) {
-              rotateRight()
-            } else {
-              rotateLeft()
-            }
-            lastRotateX = move.clientX
-          }
+          lastRotateX += applyDragSteps(move.clientX - lastRotateX, rotateLeft, rotateRight)
         }
       }
       const onUp = () => {
@@ -137,6 +127,10 @@ export function ZoomModal({ frameUrls, selectedFrameIndex, setSelectedFrameIndex
       display: 'flex',
       cursor: 'pointer',
       zIndex: 1,
+      // Rapid clicks shouldn't initiate a text-selection drag into the
+      // close-button glyph or any other overlay text.
+      userSelect: 'none',
+      WebkitUserSelect: 'none',
     },
     chevronLeft: {
       left: '8px',
@@ -186,10 +180,10 @@ export function ZoomModal({ frameUrls, selectedFrameIndex, setSelectedFrameIndex
           <img src={imageUrl} css={css.image} alt="" onMouseDown={handleImageMouseDown} />
         </div>
       </div>
-      <div css={{ ...css.chevron, ...css.chevronLeft }} onClick={rotateLeft}>
+      <div css={{ ...css.chevron, ...css.chevronLeft }} onMouseDown={(e) => e.preventDefault()} onClick={rotateLeft}>
         <ChevronLeftIcon css={css.chevronIcon} />
       </div>
-      <div css={{ ...css.chevron, ...css.chevronRight }} onClick={rotateRight}>
+      <div css={{ ...css.chevron, ...css.chevronRight }} onMouseDown={(e) => e.preventDefault()} onClick={rotateRight}>
         <ChevronRightIcon css={css.chevronIcon} />
       </div>
       <button css={css.close} onClick={onClose} aria-label="Close zoom">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import { _init as initAsset } from '@/lib/asset'
 import { getConfig, EnvName } from '@/lib/config'
 import { _init as initFirebase, getAuthManager } from '@/lib/firebase'
 import type { TestHooks } from '@/lib/firebase-mock'
-import { _init as initFittingRoom } from '@/lib/fitting-room-storage'
+import { _init as initFittingRoom, syncCurrentProductSelection } from '@/lib/fitting-room-storage'
 import { i18n } from '@/lib/locale'
 import { _init as initLogger, getLogger } from '@/lib/logger'
 import { _init as initProduct } from '@/lib/product'
@@ -173,9 +173,12 @@ export async function logout() {
   logger.logInfo('User logged out')
 }
 
+export { syncCurrentProductSelection }
+
 const TFR = {
   init,
   logout,
+  syncCurrentProductSelection,
 }
 
 export default TFR

--- a/src/lib/fitting-room-storage.ts
+++ b/src/lib/fitting-room-storage.ts
@@ -58,16 +58,67 @@ export function _init(): void {
   const { brandId } = getStaticData()
   const items = readFittingRoom(brandId)
   useMainStore.setState({ fittingRoom: items })
+
+  // Cross-tab freshness: localStorage fires `storage` on *other* tabs
+  // (not the writing tab) whenever a key changes. When another tab
+  // mutates the fitting room, re-read from localStorage so this tab's
+  // in-memory model — and any UI subscribing to it — stays in sync.
+  // The writing tab doesn't get this event, which is correct (would
+  // otherwise loop). `e.newValue === null` covers the case where the
+  // key was cleared entirely; readFittingRoom handles that.
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', (e) => {
+      if (e.key !== STORAGE_KEY) {
+        return
+      }
+      useMainStore.setState({ fittingRoom: readFittingRoom(brandId) })
+    })
+  }
+}
+
+// Resolve a colorway_size_asset id from a (size, color) selection for
+// currentProduct. Returns null when productData hasn't loaded yet, when the
+// size doesn't match any known recommendation, or when the color doesn't
+// match any variant's SKU. Callers store the null and downstream resolve
+// paths (e.g. ensureSizeForItem in the fitting-room overlay) re-derive when
+// productData becomes available.
+function resolveCurrentProductCsaId(productId: string, size: string | null, color: string | null): number | null {
+  if (size == null) {
+    return null
+  }
+  const { currentProduct } = getStaticData()
+  if (!currentProduct) {
+    return null
+  }
+  const stored = useMainStore.getState().productData[productId]
+  if (!stored || 'error' in stored) {
+    return null
+  }
+  const sizeRec = stored.sizeFitRecommendation.available_sizes.find((s) => getSizeLabelFromSize(s) === size)
+  if (!sizeRec) {
+    return null
+  }
+  const csa = sizeRec.colorway_size_assets.find((c) => {
+    const variant = currentProduct.variants.find((v) => v.sku === c.sku)
+    return variant?.color === color
+  })
+  return csa?.id ?? null
 }
 
 // The add path shared by toggleFittingRoomItem and ensureFittingRoomItem.
+//
+// We deliberately do NOT capture the PDP's currently-selected size. Size
+// belongs to the TFR size-recommendation flow: the fitting-room overlay's
+// ensureSizeForItem auto-picks the recommended size for the stored color
+// the first time the shopper selects the item, and the overlay's own size
+// selector is the only place size is ever persisted. Storing the PDP size
+// here would override that — typically with something the shopper picked
+// before the size recommendation existed.
 async function addFittingRoomItem(productId: string, handle: string | null, isPdp: boolean): Promise<void> {
   const state = useMainStore.getState()
   logger.logDebug('{{ts}} - Adding to fitting room', { productId, handle, isPdp })
 
-  let size: string | null = null
   let color: string | null = null
-  let colorwaySizeAssetId: number | null = null
   let resolvedHandle: string | null = handle
 
   if (isPdp) {
@@ -78,24 +129,9 @@ async function addFittingRoomItem(productId: string, handle: string | null, isPd
       }
       try {
         const selection = await currentProduct.getSelectedOptions()
-        size = selection.size || null
         color = selection.color
       } catch (error) {
         logger.logWarn('Failed to read selected options from currentProduct', { error })
-      }
-
-      const stored = state.productData[productId]
-      if (stored && !('error' in stored) && size != null) {
-        const sizeRec = stored.sizeFitRecommendation.available_sizes.find((s) => getSizeLabelFromSize(s) === size)
-        if (sizeRec) {
-          const csa = sizeRec.colorway_size_assets.find((c) => {
-            const variant = currentProduct.variants.find((v) => v.sku === c.sku)
-            return variant?.color === color
-          })
-          if (csa) {
-            colorwaySizeAssetId = csa.id
-          }
-        }
       }
     }
   }
@@ -103,10 +139,57 @@ async function addFittingRoomItem(productId: string, handle: string | null, isPd
   state.addToFittingRoom({
     externalId: productId,
     handle: resolvedHandle,
-    size,
+    size: null,
+    color,
+    colorwaySizeAssetId: null,
+    addedAt: Date.now(),
+  })
+}
+
+// Re-read currentProduct's selected color and, if the product is already in
+// the fitting-room storage, write the new color (and re-resolved CSA) to
+// its entry. Intended use: the host theme calls this whenever the PDP's
+// variant selector changes, so the shopper's latest color pick is reflected
+// the next time they open any TFR overlay.
+//
+// PDP size is deliberately ignored — size belongs to the TFR size-rec flow,
+// not the PDP. Any size the shopper picked inside a TFR overlay is
+// preserved; we recompute CSA from (existing size, new color) so the stored
+// CSA stays consistent with the new color choice.
+//
+// No-op when there's no currentProduct (e.g. we're on a collection page),
+// when the product isn't in the fitting room, or when the new color matches
+// what's already stored. Safe to call as often as needed.
+export async function syncCurrentProductSelection(): Promise<void> {
+  const { currentProduct } = getStaticData()
+  if (!currentProduct) {
+    return
+  }
+  const state = useMainStore.getState()
+  const existing = state.fittingRoom.find((item) => item.externalId === currentProduct.externalId)
+  if (!existing) {
+    return
+  }
+
+  let color: string | null = null
+  try {
+    const selection = await currentProduct.getSelectedOptions()
+    color = selection.color
+  } catch (error) {
+    logger.logWarn('syncCurrentProductSelection: failed to read selected options', { error })
+    return
+  }
+
+  if (color === existing.color) {
+    return
+  }
+
+  const colorwaySizeAssetId = resolveCurrentProductCsaId(currentProduct.externalId, existing.size, color)
+  state.updateFittingRoomItem(currentProduct.externalId, { color, colorwaySizeAssetId })
+  logger.logDebug('{{ts}} - Synced PDP color into fitting-room', {
+    externalId: currentProduct.externalId,
     color,
     colorwaySizeAssetId,
-    addedAt: Date.now(),
   })
 }
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -3,7 +3,7 @@ import type { Config } from '@/lib/config'
 import type { AuthUser, UserProfile } from '@/lib/firebase'
 import type { TestHooks } from '@/lib/firebase-mock'
 import type { FittingRoomItem } from '@/lib/fitting-room-storage'
-import { writeFittingRoom } from '@/lib/fitting-room-storage'
+import { readFittingRoom, writeFittingRoom } from '@/lib/fitting-room-storage'
 import type { LoadedProductData, LoadedProductError } from '@/lib/product'
 import type { OverlayName } from '@/lib/view'
 import { DeviceLayout } from '@/lib/view'
@@ -144,26 +144,37 @@ export const useMainStore = create<MainStoreState>((set) => ({
     })),
 
   // Fitting room:
+  //
+  // Each mutation reads the latest localStorage state before applying the
+  // change, so two tabs adding different products at the same time merge
+  // instead of last-write-wins. The in-memory Zustand value is just a
+  // cache of "what was in localStorage the last time we touched it".
+  // Cross-tab UI freshness (Tab B's open fitting-room sees Tab A's add
+  // without a mutation of its own) is handled by the `storage` event
+  // listener registered in fitting-room-storage.ts::_init.
   fittingRoom: [],
   addToFittingRoom: (item: FittingRoomItem) =>
-    set((prevState) => {
-      const filtered = prevState.fittingRoom.filter((existing) => existing.externalId !== item.externalId)
-      const next = [...filtered, item]
-      writeFittingRoom(getStaticData().brandId, next)
+    set(() => {
+      const brandId = getStaticData().brandId
+      const fresh = readFittingRoom(brandId)
+      const next = [...fresh.filter((existing) => existing.externalId !== item.externalId), item]
+      writeFittingRoom(brandId, next)
       return { fittingRoom: next }
     }),
   removeFromFittingRoom: (externalId: string) =>
-    set((prevState) => {
-      const next = prevState.fittingRoom.filter((existing) => existing.externalId !== externalId)
-      writeFittingRoom(getStaticData().brandId, next)
+    set(() => {
+      const brandId = getStaticData().brandId
+      const fresh = readFittingRoom(brandId)
+      const next = fresh.filter((existing) => existing.externalId !== externalId)
+      writeFittingRoom(brandId, next)
       return { fittingRoom: next }
     }),
   updateFittingRoomItem: (externalId: string, patch: Partial<FittingRoomItem>) =>
-    set((prevState) => {
-      const next = prevState.fittingRoom.map((existing) =>
-        existing.externalId === externalId ? { ...existing, ...patch } : existing,
-      )
-      writeFittingRoom(getStaticData().brandId, next)
+    set(() => {
+      const brandId = getStaticData().brandId
+      const fresh = readFittingRoom(brandId)
+      const next = fresh.map((existing) => (existing.externalId === externalId ? { ...existing, ...patch } : existing))
+      writeFittingRoom(brandId, next)
       return { fittingRoom: next }
     }),
   clearFittingRoom: () =>

--- a/tests/e2e/fixtures/seed.ts
+++ b/tests/e2e/fixtures/seed.ts
@@ -72,3 +72,58 @@ export const TEST_VTO_COMPOSITION = {
   token: 'tok-test-1',
   frames: ['user-test/avatar-1/vto-tok-test-1/frames/image_0.png'],
 }
+
+// --- Rich VTO fixtures ----------------------------------------------------
+// These let a test exercise the full quick-view VTO flow: SDK boot → style
+// resolved from firestore → /v1/styles/<id>/recommendation returns sizes with
+// CSAs → /v1/vto-compositions returns multiple frames → AvatarFrameViewer
+// renders the first frame and useAutoRotate cycles through the rest.
+
+// 12-frame VTO response — enough for the auto-rotate tests to assert frame
+// advancement over a 1-2s window without flake risk from very small N.
+export const TEST_VTO_COMPOSITION_12 = {
+  token: 'tok-test-12',
+  frames: Array.from({ length: 12 }, (_, i) => `user-test/avatar-1/vto-test/frames/image_${i}.png`),
+}
+
+// Minimal-but-valid SizeFitRecommendation. The recommended size has a CSA
+// whose SKU matches TEST_CURRENT_PRODUCT.variants[0] so quick-view's
+// setupInitialVtoData finds a usable CSA without choking on missing data.
+export const TEST_SIZE_FIT_RECOMMENDATION = {
+  fit_classification: 'regular_fit',
+  recommended_size: {
+    id: 101,
+    label: 'M',
+    size_value: { value: 'M' },
+    colorway_size_assets: [{ id: 5001, sku: 'SKU-M-BLUE' }],
+  },
+  available_sizes: [
+    {
+      id: 101,
+      label: 'M',
+      size_value: { value: 'M' },
+      colorway_size_assets: [{ id: 5001, sku: 'SKU-M-BLUE' }],
+    },
+    {
+      id: 102,
+      label: 'S',
+      size_value: { value: 'S' },
+      colorway_size_assets: [{ id: 5002, sku: 'SKU-S-BLUE' }],
+    },
+  ],
+  fits: [
+    { size_id: 101, measurement_location_fits: [] },
+    { size_id: 102, measurement_location_fits: [] },
+  ],
+}
+
+// One firestore-seeded style document. id matches the size-recommendation
+// endpoint (/v1/styles/<id>/recommendation). external_id matches
+// TEST_PRODUCT_EXTERNAL_ID so the firestore lookup hits when quick-view
+// loads product data. Seed via bootSdk({ firestoreDocs: { styles: { ... } } }).
+export const TEST_SEEDED_STYLE = {
+  id: TEST_STYLE_ID,
+  brand_id: TEST_BRAND_ID,
+  external_id: TEST_PRODUCT_EXTERNAL_ID,
+  style_category_name: 'tshirt',
+}

--- a/tests/e2e/helpers/boot.ts
+++ b/tests/e2e/helpers/boot.ts
@@ -16,6 +16,12 @@ export interface BootSdkOptions {
   currentProduct?: typeof TEST_CURRENT_PRODUCT | null
   loggedIn?: boolean // default true (seeds TestHooks.auth with the standard test user)
   apiOverrides?: ApiMockOverrides
+  // Pre-seeded firestore documents. Keyed by collection → docId → data. The
+  // MockFirestoreManager's queryDocs returns every doc in the collection
+  // regardless of constraints, so doc IDs are arbitrary — the doc shape just
+  // needs the fields the SDK actually reads. See fixtures/seed.ts for
+  // ready-made shapes (e.g. TEST_SEEDED_STYLE).
+  firestoreDocs?: Record<string, Record<string, unknown>>
 }
 
 /**
@@ -24,7 +30,13 @@ export interface BootSdkOptions {
  * the host fixture dispatches).
  */
 export async function bootSdk(page: Page, options: BootSdkOptions = {}): Promise<void> {
-  const { brandId = TEST_BRAND_ID, currentProduct = TEST_CURRENT_PRODUCT, loggedIn = true, apiOverrides } = options
+  const {
+    brandId = TEST_BRAND_ID,
+    currentProduct = TEST_CURRENT_PRODUCT,
+    loggedIn = true,
+    apiOverrides,
+    firestoreDocs,
+  } = options
 
   await installApiMocks(page, apiOverrides)
 
@@ -32,12 +44,19 @@ export async function bootSdk(page: Page, options: BootSdkOptions = {}): Promise
   // script runs. The fixture HTML reads `__TFR_TEST_CONFIG__` and threads it
   // into `init({ ..., testHooks })`.
   await page.addInitScript(
-    ({ brandId, currentProduct, loggedIn, uid, email, idToken, profile }) => {
+    ({ brandId, currentProduct, loggedIn, uid, email, idToken, profile, firestoreDocs }) => {
+      const testHooks: Record<string, unknown> = {}
+      if (loggedIn) {
+        testHooks.auth = { uid, email, idToken, profile }
+      }
+      if (firestoreDocs) {
+        testHooks.firestore = { docs: firestoreDocs }
+      }
       ;(window as unknown as { __TFR_TEST_CONFIG__: unknown }).__TFR_TEST_CONFIG__ = {
         brandId,
         environment: 'demo',
         currentProduct,
-        testHooks: loggedIn ? { auth: { uid, email, idToken, profile } } : {},
+        testHooks,
       }
     },
     {
@@ -48,6 +67,7 @@ export async function bootSdk(page: Page, options: BootSdkOptions = {}): Promise
       email: TEST_EMAIL,
       idToken: TEST_ID_TOKEN,
       profile: TEST_USER_PROFILE,
+      firestoreDocs: firestoreDocs ?? null,
     },
   )
 

--- a/tests/e2e/quick-view-vto.spec.ts
+++ b/tests/e2e/quick-view-vto.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+import { TEST_SEEDED_STYLE, TEST_SIZE_FIT_RECOMMENDATION, TEST_VTO_COMPOSITION_12 } from './fixtures/seed'
+
+// End-to-end coverage for the quick-view VTO flow: style resolved from
+// firestore → /v1/styles/{id}/recommendation → /v1/vto-compositions →
+// AvatarFrameViewer renders → useAutoRotate plays.
+//
+// The auto-rotate behaviour broke twice during a single session (stops-after-
+// 1-frame from React 18's deferred-updater batching; stops-after-N from
+// prefetch landings tearing down the effect). Both tests below directly
+// regression-protect those failure modes; the user-cancel test additionally
+// locks in the onUserInteract → cancelAutoRotate wiring.
+
+const RICH_BOOT = {
+  apiOverrides: {
+    sizeRecommendation: (route: { fulfill: (r: { json: unknown }) => Promise<void> }) =>
+      route.fulfill({ json: TEST_SIZE_FIT_RECOMMENDATION }),
+    vtoComposition: (route: { fulfill: (r: { json: unknown }) => Promise<void> }) =>
+      route.fulfill({ json: TEST_VTO_COMPOSITION_12 }),
+  },
+  firestoreDocs: { styles: { 'style-1': TEST_SEEDED_STYLE } },
+}
+
+// Pulls the integer N out of an image_N.png frame URL. Lets tests assert on
+// "the displayed frame index" without coupling to the rest of the URL shape.
+function frameIndexFromSrc(src: string | null): number | null {
+  const m = src?.match(/image_(\d+)\.png/)
+  return m ? Number(m[1]) : null
+}
+
+test('quick-view: VTO frames load and auto-rotate advances through them', async ({ page }) => {
+  await bootSdk(page, RICH_BOOT)
+  await page.getByRole('button', { name: /quick view/i }).click()
+
+  const avatar = page.locator('img[src*="image_"]')
+
+  // Frame 0 should land first — produced by the default-to-0 effect in
+  // AvatarFrameViewer the moment frameUrls arrives.
+  await expect(avatar).toHaveAttribute('src', /image_0\.png/, { timeout: 5000 })
+
+  // useAutoRotate ticks every 500ms, so within ~3s we should be well past
+  // frame 0. Asserting "advanced to >= 3" (rather than a specific index)
+  // tolerates timer jitter without weakening the bug coverage — the regressed
+  // versions stopped at 0 or 1.
+  await expect
+    .poll(async () => frameIndexFromSrc(await avatar.getAttribute('src')), { timeout: 3000 })
+    .toBeGreaterThanOrEqual(3)
+})
+
+test('quick-view: chevron click cancels the auto-rotate', async ({ page }) => {
+  await bootSdk(page, RICH_BOOT)
+  await page.getByRole('button', { name: /quick view/i }).click()
+
+  const avatar = page.locator('img[src*="image_"]')
+  await expect(avatar).toHaveAttribute('src', /image_0\.png/, { timeout: 5000 })
+
+  // Click the right chevron once. rotateRight advances frame 0 → 1 AND fires
+  // onUserInteract → cancelAutoRotate. If the cancellation breaks, the
+  // auto-rotate will keep ticking and march past frame 1 within ~2s.
+  await page.getByRole('button', { name: 'Rotate right', exact: true }).click()
+  await expect(avatar).toHaveAttribute('src', /image_1\.png/, { timeout: 1000 })
+
+  // Hold for 2s — at 500ms/tick the rotation would reach frame 5 if it weren't
+  // cancelled. Anything past frame 1 means the cancel wiring is broken.
+  await page.waitForTimeout(2000)
+  const finalIndex = frameIndexFromSrc(await avatar.getAttribute('src'))
+  expect(finalIndex).toBe(1)
+})


### PR DESCRIPTION
## Summary

Nine commits across two themes — visual polish on the VTO overlays, and a bundle of behaviour fixes on the avatar frame viewer (rotation gestures, X-to-remove, auto-rotate animation).

### Visual / layout
- **Quick-view desktop product title** 32px → 24px to match fitting-room.
- **Quick-view rotation slider** hidden behind a `SHOW_ROTATION_SLIDER = false` module-local toggle. The desktop gutter that used to reserve space for it collapses to 0, letting the avatar fill the full vertical height (image grows ~100px taller and proportionally wider). Re-enable by flipping the constant.
- **Color selector** added to quick-view mobile collapsed + expanded views (it was only in the Full view). Self-hides when there are fewer than 2 colors.

### Avatar gesture + interaction fixes
- **Fitting-room product-card X** now actually removes from storage (previously only dropped the in-overlay selection — rail card and localStorage entry both stuck around).
- **Rapid chevron clicks** no longer initiate a text-selection drag into the surrounding pill labels. \`onMouseDown preventDefault\` on the chevrons plus \`user-select: none\` on chevron containers, fitting-room pill labels, and the quick-view zoom pill.
- **Touch drag-to-rotate jankiness** root-caused and fixed: (1) multi-step floor so a fast swipe rotates N frames per touchmove instead of 1; (2) \`{ passive: false }\` on touchmove + \`touch-action: pan-y\` on the avatar img so the browser stops claiming horizontal swipes for native scroll/pull-to-refresh/swipe-back before our handler can react; (3) axis-lock with an 8px threshold (vertical drags stay native scroll, horizontal commits to rotation). Same multi-step + chevron fixes carried into the zoom modal.

### Auto-rotate animation
The avatar plays one full rotation through every frame whenever a product is added to the VTO outfit. \`useAutoRotate\` lives on the parent (Avatar in quick-view, AvatarPane in fitting-room) — quick-view passes a constant trigger of 1, fitting-room increments trigger state in \`handleSelectItem\`'s add branch. Cancel-on-user-interaction wired explicitly via an \`onUserInteract\` callback (not state-comparison inside the setter — that approach raced React 18's deferred updater and stopped the rotation after 1 tick).

Two regression tests lock the behaviour in:
- \`quick-view: VTO frames load and auto-rotate advances through them\`
- \`quick-view: chevron click cancels the auto-rotate\`

Plus reusable test infrastructure: \`bootSdk\` now accepts \`firestoreDocs\`, \`fixtures/seed.ts\` gains \`TEST_VTO_COMPOSITION_12\` / \`TEST_SIZE_FIT_RECOMMENDATION\` / \`TEST_SEEDED_STYLE\`. AvatarFrameViewer chevrons get \`role="button"\` + aria-label (a11y win + lets the test target by role).

## Test plan
- [x] Quick-view desktop: title is the smaller size, no rotation slider, avatar fills the vertical space, auto-rotates once on open, chevron click stops the rotation.
- [x] Quick-view mobile (collapsed/expanded): color selector visible for multi-colour products, hidden for single-colour.
- [x] Fitting-room desktop: X on a product card removes it from the rail AND the entry survives an overlay reopen (i.e. it's gone from localStorage too). Adding a product triggers a full rotation; size/color changes don't.
- [ ] Fitting-room mobile: same auto-rotate on add.
- [ ] Touch drag on a phone/emulator feels smooth from the first swipe; vertical swipes still scroll the page; horizontal swipes rotate.
- [ ] Zoom modal: rapid chevron clicks don't select text; mouse drag through the rotate region cycles smoothly.
- [ ] \`npm run check\` clean, all 6 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)