### PR TITLE
Fitting-room: Clear All + Sign Out reorg; PDP color → rail card image; device test hook

### DIFF
--- a/src/components/overlays/fitting-room/desktop-layout.tsx
+++ b/src/components/overlays/fitting-room/desktop-layout.tsx
@@ -47,6 +47,7 @@ interface DesktopLayoutProps {
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
   onSignOut: () => void
+  onClearAll: () => void
 }
 
 // DesktopLayout. 2-column when no items selected (avatar + card rails);
@@ -70,6 +71,7 @@ export function DesktopLayout({
   onAddToCart,
   onToggleUntuck,
   onSignOut,
+  onClearAll,
 }: DesktopLayoutProps) {
   const hasSelection = selectedItems.length > 0
   // Avatar-pane hover collapses the AvatarControls pills to icon-only when
@@ -152,32 +154,44 @@ export function DesktopLayout({
       gap: '24px',
       padding: `26px ${EDGE_INSET_PX}px ${EDGE_INSET_PX}px 8px`,
     },
-    // Sign-out is overlaid on the top-right corner of the rails column so it
-    // shares a row with the first card-rail header rather than reserving its
-    // own row. It scrolls away with the content, which is fine — it only
-    // needs to overlap that first header.
-    signOutWrapper: {
-      position: 'absolute',
-      // Near the overlay top, partially overlapping the first card-rail
-      // header row below it.
-      top: '15px',
-      right: '24px',
-      zIndex: 3,
+    // Shared icon+link visual for the rails column's two utility actions
+    // (Clear All in the top-right corner, Sign Out at the bottom). Callers
+    // add their own positioning on top.
+    utilityLink: {
       display: 'inline-flex',
       alignItems: 'center',
       gap: '8px',
       cursor: 'pointer',
       color: _theme.color_tfr_800,
     },
-    signOutIcon: {
+    utilityIcon: {
       width: '12px',
       height: '22px',
       fill: _theme.color_tfr_800,
       flex: 'none',
     },
-    signOut: {
+    utilityText: {
       color: _theme.color_tfr_800,
       fontSize: '14px',
+    },
+    // Clear All is overlaid on the top-right corner of the rails column so it
+    // shares a row with the first card-rail header rather than reserving its
+    // own row. It scrolls away with the content, which is fine — it only
+    // needs to overlap that first header.
+    clearAllWrapper: {
+      position: 'absolute',
+      top: '15px',
+      right: '24px',
+      zIndex: 3,
+    },
+    // Sign Out sits at the bottom of the rails column, after the last card
+    // rail. It scrolls with the content — visible once the shopper reaches
+    // the end of their items. marginTop: auto in a flex column would only
+    // help with a non-scrolling parent; here the scroll context makes a
+    // top margin enough to separate it from the last rail above.
+    signOutWrapper: {
+      marginTop: '8px',
+      justifyContent: 'center',
     },
   }))
 
@@ -230,9 +244,8 @@ export function DesktopLayout({
         </div>
       ) : null}
       <div css={css.railsColumn}>
-        <span css={css.signOutWrapper} onClick={onSignOut}>
-          <TfrIcon css={css.signOutIcon} />
-          <LinkT variant="underline" css={css.signOut} t="fitting_room.sign_out" />
+        <span css={{ ...css.utilityLink, ...css.clearAllWrapper }} onClick={onClearAll}>
+          <LinkT variant="underline" css={css.utilityText} t="fitting_room.clear_all" />
         </span>
         {resolved.groups.map((group) => (
           <CardRail
@@ -243,6 +256,10 @@ export function DesktopLayout({
             onRemoveItem={onRemoveItem}
           />
         ))}
+        <span css={{ ...css.utilityLink, ...css.signOutWrapper }} onClick={onSignOut}>
+          <TfrIcon css={css.utilityIcon} />
+          <LinkT variant="underline" css={css.utilityText} t="fitting_room.sign_out" />
+        </span>
       </div>
       {zoomOpen && frameUrls && frameUrls.length > 0 ? (
         <ZoomModal

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -563,6 +563,8 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             onChangeColor={handleChangeColor}
             onAddToCart={handleAddToCart}
             onToggleUntuck={handleToggleUntuck}
+            onSignOut={handleSignOut}
+            onClearAll={handleClearAll}
           />
         ) : (
           <DesktopLayout

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -67,6 +67,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
   const openOverlay = useMainStore((state) => state.openOverlay)
   const updateFittingRoomItem = useMainStore((state) => state.updateFittingRoomItem)
   const removeFromFittingRoom = useMainStore((state) => state.removeFromFittingRoom)
+  const clearFittingRoom = useMainStore((state) => state.clearFittingRoom)
   const resolved = useResolvedFittingRoom()
 
   const [topOffset, setTopOffset] = useState<number>(0)
@@ -432,6 +433,15 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
     })
   }, [closeOverlay])
 
+  // Clear All: wipe every entry from fitting-room storage AND reset overlay-
+  // local state (selected set, open accordion) so the UI reflects the empty
+  // room immediately without waiting for the next render-cycle decision.
+  const handleClearAll = useCallback(() => {
+    clearFittingRoom()
+    setSelectedExternalIds(new Set())
+    setOpenAccordionItemId(null)
+  }, [clearFittingRoom])
+
   const handleShopNow = useCallback(() => {
     closeOverlay()
   }, [closeOverlay])
@@ -574,6 +584,7 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
             onAddToCart={handleAddToCart}
             onToggleUntuck={handleToggleUntuck}
             onSignOut={handleSignOut}
+            onClearAll={handleClearAll}
           />
         )}
         {vtoError ? <Snackbar messageKey="fitting_room.vto_error" onDismiss={clearVtoError} /> : null}

--- a/src/components/overlays/fitting-room/mobile-layout.tsx
+++ b/src/components/overlays/fitting-room/mobile-layout.tsx
@@ -220,9 +220,10 @@ function BrowseView({
       color: theme.color_tfr_800,
       fontSize: '14px',
     },
-    // Clear All — black pill matching the section-menu pill at the top-right.
-    // Positioned absolute over the BrowseView container, in the bottom-right
-    // corner with enough offset to clear the Try It On CTA bar below it.
+    // Clear All — white pill with thin black border, black text. Positioned
+    // absolute over the BrowseView container, bottom-right, offset to clear
+    // the Try It On CTA bar below it. Pill shape matches the SectionNav
+    // pill at the top-right, but inverted on color for visual contrast.
     clearAllPill: {
       position: 'absolute',
       bottom: '96px',
@@ -233,9 +234,9 @@ function BrowseView({
       gap: '8px',
       padding: '6px 16px',
       borderRadius: '999px',
-      backgroundColor: theme.color_fg_text,
-      color: '#FFFFFF',
-      border: 'none',
+      backgroundColor: '#FFFFFF',
+      color: theme.color_fg_text,
+      border: `1px solid ${theme.color_fg_text}`,
       cursor: 'pointer',
       fontSize: '13px',
       fontWeight: '500',
@@ -244,18 +245,14 @@ function BrowseView({
       whiteSpace: 'nowrap',
     },
     clearAllText: {
-      color: '#FFFFFF',
+      color: theme.color_fg_text,
     },
     clearAllIcon: {
       width: '12px',
       height: '12px',
       flex: 'none',
-      // close-icon.svg's <path>s have a hardcoded dark fill, not
-      // currentColor, so we override the descendant fills directly to make
-      // the X show up against the dark pill background.
-      '& path': {
-        fill: '#FFFFFF',
-      },
+      // close-icon.svg's <path>s have a hardcoded dark fill — already matches
+      // the new black-on-white pill, no override needed.
     },
     bottomBar: {
       flex: 'none',

--- a/src/components/overlays/fitting-room/mobile-layout.tsx
+++ b/src/components/overlays/fitting-room/mobile-layout.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button, ButtonT } from '@/components/button'
-import { Text } from '@/components/text'
+import { Text, TextT } from '@/components/text'
 import type { ResolvedFittingRoom, ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
-import { DragHandleIcon, LeftArrowIcon } from '@/lib/asset'
+import { CloseIcon, DragHandleIcon, LeftArrowIcon, TfrIcon } from '@/lib/asset'
+import { LinkT } from '@/components/link'
 import type { SheetSnap } from '@/lib/use-mobile-sheet-snap'
 import type { StyleProp } from '@/lib/theme'
 import { useCss } from '@/lib/theme'
@@ -44,6 +45,8 @@ interface MobileLayoutProps {
   onChangeColor: (externalId: string, colorLabel: string | null) => void
   onAddToCart: (externalId: string) => void
   onToggleUntuck: () => void
+  onSignOut: () => void
+  onClearAll: () => void
 }
 
 // MobileLayout switches between two view modes inside the same overlay:
@@ -72,6 +75,8 @@ export function MobileLayout({
   onChangeColor,
   onAddToCart,
   onToggleUntuck,
+  onSignOut,
+  onClearAll,
 }: MobileLayoutProps) {
   if (mode === 'browse') {
     return (
@@ -82,6 +87,8 @@ export function MobileLayout({
         onSelectItem={onSelectItem}
         onRemoveItem={onRemoveItem}
         onTryItOn={onTryItOn}
+        onSignOut={onSignOut}
+        onClearAll={onClearAll}
       />
     )
   }
@@ -114,6 +121,8 @@ function BrowseView({
   onSelectItem,
   onRemoveItem,
   onTryItOn,
+  onSignOut,
+  onClearAll,
 }: {
   resolved: ResolvedFittingRoom
   availabilityByExternalId: Record<string, Availability>
@@ -121,6 +130,8 @@ function BrowseView({
   onSelectItem: (externalId: string) => void
   onRemoveItem: (externalId: string) => void
   onTryItOn: () => void
+  onSignOut: () => void
+  onClearAll: () => void
 }) {
   const railsAreaRef = useRef<HTMLDivElement>(null)
   // group name → its wrapper element in the rails scroll area, for the
@@ -170,13 +181,13 @@ function BrowseView({
     container.scrollBy({ top: delta - SECTION_SCROLL_TOP_GAP_PX, behavior: 'smooth' })
   }, [])
 
-  const css = useCss((_theme) => ({
+  const css = useCss((theme) => ({
     container: {
       display: 'flex',
       flexDirection: 'column',
       height: '100%',
       width: '100%',
-      // Positioning context for the floating SectionNav pill.
+      // Positioning context for the floating SectionNav + Clear All pills.
       position: 'relative',
     },
     railsArea: {
@@ -186,6 +197,65 @@ function BrowseView({
       display: 'flex',
       flexDirection: 'column',
       gap: '24px',
+    },
+    // Sign Out lives at the very bottom of the scrollable card list — same
+    // pattern as desktop. Centered icon+link in TFR teal. Scrolls into view
+    // once the shopper reaches the end of their items.
+    signOutWrapper: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '8px',
+      cursor: 'pointer',
+      color: theme.color_tfr_800,
+      marginTop: '8px',
+    },
+    signOutIcon: {
+      width: '12px',
+      height: '22px',
+      fill: theme.color_tfr_800,
+      flex: 'none',
+    },
+    signOutText: {
+      color: theme.color_tfr_800,
+      fontSize: '14px',
+    },
+    // Clear All — black pill matching the section-menu pill at the top-right.
+    // Positioned absolute over the BrowseView container, in the bottom-right
+    // corner with enough offset to clear the Try It On CTA bar below it.
+    clearAllPill: {
+      position: 'absolute',
+      bottom: '96px',
+      right: '16px',
+      zIndex: 5,
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '8px',
+      padding: '6px 16px',
+      borderRadius: '999px',
+      backgroundColor: theme.color_fg_text,
+      color: '#FFFFFF',
+      border: 'none',
+      cursor: 'pointer',
+      fontSize: '13px',
+      fontWeight: '500',
+      letterSpacing: '0.5px',
+      textTransform: 'uppercase',
+      whiteSpace: 'nowrap',
+    },
+    clearAllText: {
+      color: '#FFFFFF',
+    },
+    clearAllIcon: {
+      width: '12px',
+      height: '12px',
+      flex: 'none',
+      // close-icon.svg's <path>s have a hardcoded dark fill, not
+      // currentColor, so we override the descendant fills directly to make
+      // the X show up against the dark pill background.
+      '& path': {
+        fill: '#FFFFFF',
+      },
     },
     bottomBar: {
       flex: 'none',
@@ -222,7 +292,22 @@ function BrowseView({
             />
           </div>
         ))}
+        {/* Bottom of the scrollable card list — same pattern as desktop. */}
+        <span css={css.signOutWrapper} onClick={onSignOut}>
+          <TfrIcon css={css.signOutIcon} />
+          <LinkT variant="underline" css={css.signOutText} t="fitting_room.sign_out" />
+        </span>
       </div>
+      {/* Floating Clear All pill — bottom-right of the BrowseView container,
+          mirrors the SectionNav pill at the top-right. The pill carries the
+          uppercase + font-size styling; the explicit color override on the
+          inner TextT is needed because Text's `base` variant sets its own
+          color (theme.color_fg_text) which would otherwise win over the
+          pill's white. */}
+      <Button variant="base" css={css.clearAllPill} onClick={onClearAll}>
+        <TextT variant="base" css={css.clearAllText} t="fitting_room.clear_all" />
+        <CloseIcon css={css.clearAllIcon} />
+      </Button>
       {/* Hold the CTA back until the card rails have resolved — otherwise it
           briefly renders alone (with an empty rails area collapsed to zero
           height) and floats up to the top of the overlay. */}

--- a/src/components/overlays/fitting-room/product-card.tsx
+++ b/src/components/overlays/fitting-room/product-card.tsx
@@ -110,8 +110,26 @@ export function ProductCard({ item, availability, onClick, onRemove }: ProductCa
   // default. Falls back through: variant.imageUrl → product.imageUrl, and
   // variant.priceFormatted → variants[0].priceFormatted, so single-colour
   // products and items without per-variant images still render.
+  //
+  // When storage.color is null (catalog-add path — no PDP to read color
+  // from), match the color that ensureSizeForItem will auto-pick on tap:
+  // the recommended size's first CSA. Without this, the card shows the
+  // merchant's featured image (often a different color) and then "jumps"
+  // to the auto-picked color the moment the shopper taps it. If
+  // loadedProduct hasn't landed yet, fall through to the existing
+  // product.imageUrl fallback and let the card re-render once it does.
+  let effectiveColor = item.storage.color
+  if (!effectiveColor && item.loadedProduct) {
+    const sizeRec = item.loadedProduct.sizeFitRecommendation
+    const recommendedSize = sizeRec.available_sizes.find((s) => s.id === sizeRec.recommended_size.id)
+    const firstCsa = recommendedSize?.colorway_size_assets[0]
+    if (firstCsa) {
+      const variant = item.merchantProduct?.variants.find((v) => v.sku === firstCsa.sku)
+      effectiveColor = variant?.color ?? null
+    }
+  }
   const selectedVariant = item.merchantProduct?.variants.find(
-    (v) => v.color === item.storage.color && (!item.storage.size || v.size === item.storage.size),
+    (v) => v.color === effectiveColor && (!item.storage.size || v.size === item.storage.size),
   )
   const imageUrl = selectedVariant?.imageUrl ?? item.merchantProduct?.imageUrl ?? null
   const price = selectedVariant?.priceFormatted ?? item.merchantProduct?.variants[0]?.priceFormatted ?? null

--- a/src/lib/firebase-mock.ts
+++ b/src/lib/firebase-mock.ts
@@ -20,6 +20,9 @@ const logger = getLogger('firebase-mock')
  * `auth` omitted → simulates a logged-out shopper.
  * `auth.profile` provided → auto-seeds `firestore.docs.users[uid]` so callers
  * only need to specify the profile once.
+ * `device` provided → overrides view.ts's Bowser/touch-based DeviceLayout
+ * detection. Lets tests (or `?tfr-test-device=…` on the theme URL) force a
+ * specific layout without spoofing user-agent + touch capability.
  */
 export interface TestHooks {
   auth?: {
@@ -30,6 +33,14 @@ export interface TestHooks {
   }
   firestore?: {
     docs?: Record<string, Record<string, Record<string, unknown>>>
+  }
+  // `layout` is a string union of the DeviceLayout enum values; using a string
+  // type here avoids a cycle (TestHooks → DeviceLayout → ... → TestHooks via
+  // store.ts). view.ts casts to DeviceLayout at the use site.
+  device?: {
+    layout: 'mobile-portrait' | 'mobile-landscape' | 'tablet-portrait' | 'tablet-landscape' | 'desktop'
+    // Defaults to `layout.startsWith('mobile')` when omitted.
+    isMobileDevice?: boolean
   }
 }
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -287,10 +287,13 @@ export function getAuthManager(): IAuthManager {
 export async function _init() {
   const { brandId, config, testHooks } = getStaticData()
 
-  // Test-only hatch: when InitParams.testHooks is set, swap in mock managers
-  // and skip Firebase entirely. Production callers never set this field, so
-  // the real init path below runs unchanged. See src/lib/firebase-mock.ts.
-  if (testHooks !== undefined) {
+  // Test-only hatch: when testHooks.auth or testHooks.firestore is set, swap
+  // in mock managers and skip Firebase entirely. Production callers never set
+  // this field; the real init path below runs unchanged. We check for the
+  // specific keys (not just `testHooks !== undefined`) so other unrelated
+  // hooks — e.g. `testHooks.device` — can be set without accidentally
+  // disabling real Firebase. See src/lib/firebase-mock.ts.
+  if (testHooks && (testHooks.auth !== undefined || testHooks.firestore !== undefined)) {
     const seedDocs: Record<string, Record<string, Record<string, unknown>>> = {
       ...(testHooks.firestore?.docs ?? {}),
     }

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -10,7 +10,7 @@ import FittingRoomIconWidget from '@/components/widgets/fitting-room-icon'
 import FittingRoomWidget from '@/components/widgets/fitting-room'
 import SizeRecWidget from '@/components/widgets/size-rec'
 import VtoButtonWidget from '@/components/widgets/vto-button'
-import { useMainStore } from '@/lib/store'
+import { getStaticData, useMainStore } from '@/lib/store'
 
 export enum DeviceLayout {
   MOBILE_PORTRAIT = 'mobile-portrait',
@@ -22,6 +22,18 @@ export enum DeviceLayout {
 
 export function _init() {
   function getDeviceData() {
+    // Test-only override. When InitParams.testHooks.device is set, skip the
+    // Bowser/touch detection below and use the caller's chosen layout. Used
+    // by the e2e suite and by `?tfr-test-device=…` on the demo theme so
+    // mobile/tablet layouts can be exercised in environments where the real
+    // signals (mobile UA, touch capability) aren't available.
+    const testDevice = getStaticData().testHooks?.device
+    if (testDevice) {
+      return {
+        isMobileDevice: testDevice.isMobileDevice ?? testDevice.layout.startsWith('mobile'),
+        deviceLayout: testDevice.layout as DeviceLayout,
+      }
+    }
     const bowserParser = Bowser.getParser(window.navigator.userAgent)
     const { width, height } = window.screen
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -18,6 +18,7 @@
     "recommended_sizes": "Recommended sizes",
     "shop_now": "Shop now",
     "sign_out": "Sign out",
+    "clear_all": "Clear All",
     "try_it_tucked_in": "Try it tucked in",
     "try_it_untucked": "Try it untucked",
     "avatar_placeholder_empty": "Add clothes to try on by selecting items in the rails.",


### PR DESCRIPTION
## Summary

Three loosely-related changes in the fitting-room overlay plus one test-infrastructure addition.

### Clear All + Sign Out reorganisation

Both layouts gain a **Clear All** affordance (calls a new \`handleClearAll\` in the overlay → \`clearFittingRoom\` Zustand action + resets in-overlay selection / open accordion state), and **Sign Out** moves to a more contextual spot.

- **Desktop**: Clear All takes the existing top-right slot of the rails column (text-only, no icon). Sign Out moves to the bottom of the rails column, after the last card rail.
- **Mobile**: Sign Out (icon + link, centered) lives at the very bottom of the scrollable card list — same pattern as desktop. Clear All is a floating pill in the bottom-right of the BrowseView container, offset to clear the Try It On CTA bar. White pill with a thin black border and a close-X to the right.

### Rail card image stops "jumping" colors on tap

When \`storage.color\` was null (catalog-add path — no PDP context), the rail card fell back to \`product.imageUrl\` (the merchant's featured image — often one specific color), and then \`ensureSizeForItem\` auto-picked a *different* color on first tap, causing the image to jump. Card now mirrors the auto-pick logic up-front: if no stored color, look up the recommended size's first CSA, derive the variant color, use its imageUrl. Before-tap and after-tap show the same image.

### \`testHooks.device\` — force DeviceLayout for testing

New optional field on \`InitParams.testHooks\`:
\`\`\`ts
device?: {
  layout: 'mobile-portrait' | 'mobile-landscape' | 'tablet-portrait' | 'tablet-landscape' | 'desktop'
  isMobileDevice?: boolean  // defaults to layout.startsWith('mobile')
}
\`\`\`

\`view.ts::getDeviceData\` checks this first and skips its normal Bowser + touch-based detection. The companion theme change (\`shopify/assets/tfr.js\`) reads \`?tfr-test-device=<layout>\` from the URL and threads it through, so we can reproduce mobile-only behavior in environments that don't get picked up as mobile naturally (Chrome DevTools responsive mode without a device preset, Playwright headless, etc.).

The firebase mock-mode check moves from \`if (testHooks !== undefined)\` to \`if (testHooks && (testHooks.auth !== undefined || testHooks.firestore !== undefined))\` so a payload that only sets \`device\` (no auth, no firestore) doesn't accidentally swap real Firebase out for the in-memory mock.

## Test plan
- [ ] Desktop fitting-room: Clear All at top-right empties the room; Sign Out at the bottom of the rails column logs out.
- [ ] Mobile fitting-room (set \`?tfr-test-device=mobile-portrait\` or use a real phone): cards browse view shows Sign Out at the bottom of the scrollable list and the white Clear All pill in the bottom-right; both work.
- [ ] Add a multi-color product from a collection page (no PDP color context), open fitting-room: the rail card image is the same color before and after tapping the card.
- [ ] Existing \`?tfr-source=local-demo\` and \`?tfr-source=local\` paths still work, and tests that don't set \`testHooks.device\` still get the default Bowser-based detection.
- [ ] \`npm run check\` clean; \`npm run test:e2e\` (6 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)