### PR TITLE
Auto-open accordion item when mobile sheet snaps to 'full'

### DIFF
--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -348,6 +348,23 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
     }
   }, [openAccordionItemId, selectedExternalIds])
 
+  // Mobile sheet snap == 'full': auto-open an accordion item so the body has
+  // something to render. Mobile's quickRow content only renders in the
+  // 'expanded' snap; in 'full' the accordion gates on `isOpen` and shows an
+  // empty body when no item is open — which is exactly the state after the
+  // second swipe-up (collapsed → expanded → full) on first try-on, before the
+  // shopper has tapped a row. Prefer the most-recently-added item; fall back
+  // to the first selected. Desktop never reaches sheetSnap='full' (no sheet),
+  // so the snap check alone is enough.
+  useEffect(() => {
+    if (sheetSnap !== 'full' || openAccordionItemId !== null || selectedItems.length === 0) {
+      return
+    }
+    const lastAddedSelected =
+      lastAddedExternalId && selectedExternalIds.has(lastAddedExternalId) ? lastAddedExternalId : null
+    setOpenAccordionItemId(lastAddedSelected ?? selectedItems[0].externalId)
+  }, [sheetSnap, openAccordionItemId, selectedItems, lastAddedExternalId, selectedExternalIds])
+
   // Preselect the current PDP product when the overlay was opened from the
   // "Try It On" CTA. The CTA adds the product to the fitting room
   // asynchronously, so wait until both the storage entry AND its backing data


### PR DESCRIPTION
## Summary

Fixes the "swipe up twice and the popover goes blank" bug in the mobile fitting-room try-on view.

### What was happening

The mobile sheet has three snap states (\`collapsed → expanded → full\`). The accordion body in \`MobileAccordionItem\` gates its content on two flags:
- \`isMobileQuickRow = sheetSnap === 'expanded' && openAccordionItemId == null\` → renders the per-item size selector
- \`isOpen\` → renders the full body (color, fit details, add to cart, etc.)

That leaves a hole: **sheetSnap == 'full' AND no item open ⇒ the body returns \`null\`** and the sheet shows nothing below the "RECOMMENDED SIZES" header. Combined with the touch handler having no \`initialSnap === 'full' && deltaY < 0\` branch (nowhere up from full), the popover looked broken: content vanished, and the title bar's swipe-up became a no-op because there's no further state to advance to.

Repro: open try-on for the first time → swipe up (collapsed → expanded, size selector appears, correct) → swipe up again on "RECOMMENDED SIZES" (expanded → full, body goes blank).

### Fix

New effect in \`FittingRoomOverlay\`: when \`sheetSnap === 'full'\` and \`openAccordionItemId === null\` and at least one item is selected, auto-open the most-recently-added still-selected item (fall back to \`selectedItems[0]\`). \`full\` consistently shows the full accordion body for one item — the "drill into details" view that snap state was designed for. Three snap states preserved.

Desktop never reaches \`sheetSnap === 'full'\` (no sheet), so the snap check alone is enough — no \`isMobileLayout\` gate needed.

## Test plan
- [ ] Mobile (real phone or \`?tfr-source=local-demo&tfr-test-device=mobile-portrait\`): open try-on, swipe up twice. Sheet now shows the full accordion body for the most-recently-added item instead of going blank.
- [ ] Swipe back down (full → collapsed); swipe back up; same item auto-opens.
- [ ] Tap a different accordion item header in \`full\` — that item opens, others close (existing behavior).
- [ ] Desktop: unchanged.
- [ ] \`npm run check\` clean; \`npm run test:e2e\` (6 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)