### PR TITLE
Fitting-room: same-category silent swap + selected-first rail + selected badge

### DIFF
--- a/src/components/overlays/fitting-room/card-rail.tsx
+++ b/src/components/overlays/fitting-room/card-rail.tsx
@@ -16,6 +16,11 @@ interface CardRailProps {
   // per-card swatch row can re-fire the colour change. When absent,
   // ProductCard skips rendering the swatch row entirely.
   onChangeColor?: (externalId: string, colorLabel: string | null) => void
+  // Desktop opts in to "selected garments float to the front of the rail",
+  // making the shopper's current outfit picks visible without horizontal
+  // scrolling. Mobile keeps the natural order so cards don't shuffle under
+  // the shopper's finger.
+  sortSelectedFirst?: boolean
 }
 
 // CardRail renders one style-category group as a collapsible section. The
@@ -28,6 +33,7 @@ export function CardRail({
   onSelectItem,
   onRemoveItem,
   onChangeColor,
+  sortSelectedFirst,
 }: CardRailProps) {
   const [collapsed, setCollapsed] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -137,7 +143,18 @@ export function CardRail({
     },
   }))
 
-  const cards = group.items.map((item) => (
+  // Stable sort: selected items float to the front while non-selected items
+  // keep their natural (backend-supplied) order. Array.prototype.sort is
+  // stable in all modern engines, so a 0/1 key on selected-ness is enough.
+  const orderedItems = sortSelectedFirst
+    ? [...group.items].sort((a, b) => {
+        const aSel = availabilityByExternalId[a.externalId] === 'selected' ? 0 : 1
+        const bSel = availabilityByExternalId[b.externalId] === 'selected' ? 0 : 1
+        return aSel - bSel
+      })
+    : group.items
+
+  const cards = orderedItems.map((item) => (
     <ProductCard
       key={item.externalId}
       item={item}

--- a/src/components/overlays/fitting-room/desktop-layout.tsx
+++ b/src/components/overlays/fitting-room/desktop-layout.tsx
@@ -255,6 +255,7 @@ export function DesktopLayout({
             onSelectItem={onSelectItem}
             onRemoveItem={onRemoveItem}
             onChangeColor={onChangeColor}
+            sortSelectedFirst
           />
         ))}
         <span css={{ ...css.utilityLink, ...css.signOutWrapper }} onClick={onSignOut}>

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -21,7 +21,7 @@ import { useMobileSheetSnap } from '@/lib/use-mobile-sheet-snap'
 import { applyFrameBaseUrl, getSizeLabelFromSize } from '@/lib/util'
 import { DeviceLayout, OverlayName } from '@/lib/view'
 import type { Availability, OutfitItem } from '@/lib/fitting-room-outfit'
-import { buildOutfit, computeAvailability } from '@/lib/fitting-room-outfit'
+import { buildOutfit, computeAvailability, getSameCategoryConflicts } from '@/lib/fitting-room-outfit'
 import { DesktopLayout } from './desktop-layout'
 import type { DetailMode } from './detail-accordion-item'
 import type { MobileMode } from './mobile-layout'
@@ -207,6 +207,18 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
           setOpenAccordionItemId(null)
         }
       } else {
+        // Silent swap: only one item per style category can be in the outfit
+        // at a time (one pair of pants, one long-sleeve top, etc), so adding
+        // a new same-category item evicts whichever same-category item was
+        // already selected. computeAvailability already reflects this (those
+        // items don't disable the new card), so the eviction is the user's
+        // implicit choice.
+        for (const evictedId of getSameCategoryConflicts(item, selectedExternalIds, resolved)) {
+          nextSelected.delete(evictedId)
+          if (openAccordionItemId === evictedId) {
+            setOpenAccordionItemId(null)
+          }
+        }
         nextSelected.add(externalId)
         ensureSizeForItem(item)
         setLastAddedExternalId(externalId)

--- a/src/components/overlays/fitting-room/product-card.tsx
+++ b/src/components/overlays/fitting-room/product-card.tsx
@@ -95,6 +95,24 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
       width: '12px',
       height: '12px',
     },
+    // Selected badge — mirrors the X button at the top-right, green-filled
+    // circle at top-left with an inline white checkmark. Only rendered when
+    // availability === 'selected'. Decorative: pointer-events: none so the
+    // shopper still taps the card body underneath to toggle off.
+    selectedBadge: {
+      position: 'absolute',
+      top: '4px',
+      left: '4px',
+      width: '24px',
+      height: '24px',
+      borderRadius: '12px',
+      backgroundColor: '#22C55E',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      pointerEvents: 'none',
+      zIndex: 1,
+    },
   }))
 
   const disabled = availability === 'disabled'
@@ -184,6 +202,19 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
       >
         <CloseIcon css={css.removeIcon} />
       </button>
+      {selected ? (
+        <div css={css.selectedBadge} aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M3 8.5L6.5 12L13 4.5"
+              stroke="#FFFFFF"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      ) : null}
       <Button
         variant="base"
         css={{

--- a/src/lib/fitting-room-outfit.ts
+++ b/src/lib/fitting-room-outfit.ts
@@ -70,6 +70,40 @@ function pairCompatible(a: StyleCategory, b: StyleCategory, group: StyleCategory
   return aIncl.includes(bName) || bIncl.includes(aName)
 }
 
+// Same-category items can never coexist in an outfit (one pair of pants,
+// one long-sleeve top, etc), but the UI handles them as a *silent swap* on
+// select: tapping a new same-category card adds it and evicts the previous
+// selection in the same category. This helper returns the externalIds that
+// would be evicted, so both the availability check (which must treat the
+// would-evict items as "not occupying a slot") and the select handler
+// (which performs the eviction) work from the same rule.
+export function getSameCategoryConflicts(
+  item: ResolvedFittingRoomItem,
+  selectedExternalIds: ReadonlySet<string>,
+  resolved: ResolvedFittingRoom,
+): string[] {
+  if (!item.styleCategory) {
+    return []
+  }
+  const itemName = catName(item.styleCategory)
+  const out: string[] = []
+  for (const sel of resolved.items) {
+    if (sel.externalId === item.externalId) {
+      continue
+    }
+    if (!selectedExternalIds.has(sel.externalId)) {
+      continue
+    }
+    if (!sel.styleCategory) {
+      continue
+    }
+    if (catName(sel.styleCategory) === itemName) {
+      out.push(sel.externalId)
+    }
+  }
+  return out
+}
+
 export function computeAvailability(
   item: ResolvedFittingRoomItem,
   selectedExternalIds: ReadonlySet<string>,
@@ -78,16 +112,25 @@ export function computeAvailability(
   if (selectedExternalIds.has(item.externalId)) {
     return 'selected'
   }
-  if (selectedExternalIds.size >= MAX_OUTFIT_ITEMS) {
+  if (!item.styleCategory) {
     return 'disabled'
   }
-  if (!item.styleCategory) {
+
+  // Same-category items would be silently evicted on add. Treat them as
+  // freed slots when computing effective outfit size and when checking
+  // pair-compatibility — they're about to leave the outfit anyway.
+  const sameCategoryEvictions = new Set(getSameCategoryConflicts(item, selectedExternalIds, resolved))
+  const effectiveSize = selectedExternalIds.size - sameCategoryEvictions.size + 1
+  if (effectiveSize > MAX_OUTFIT_ITEMS) {
     return 'disabled'
   }
 
   const itemCat = item.styleCategory
   for (const sel of resolved.items) {
     if (!selectedExternalIds.has(sel.externalId)) {
+      continue
+    }
+    if (sameCategoryEvictions.has(sel.externalId)) {
       continue
     }
     if (!sel.styleCategory) {


### PR DESCRIPTION
## Summary

Replaces the "disable card on same-category conflict" UX after user feedback that it was confusing — shoppers couldn't tell why a card was greyed out, and there was no path to swap one same-category pick for another short of removing the existing one first.

- **Same-category silent swap.** Tapping a same-category card adds it and silently evicts the previously-selected item in that category. New exported `getSameCategoryConflicts()` is consumed by both `computeAvailability` and the `handleSelectItem` swap path so the availability check and the eviction operate on one rule. Other disable cases stay the same: excludes-listed cross-group conflicts, same-group-exclusive without an includes-override, `MAX_OUTFIT_ITEMS`, and missing category. `MAX_OUTFIT_ITEMS` accounts for would-evict items, so swapping into a full outfit still works.
- **Desktop: selected cards float to the front of the rail.** Stable sort, non-selected items keep their backend order. Mobile keeps the natural order — its rail is the shopper's primary scroll surface and cards shuffling under the finger would be jarring.
- **Selected badge.** 24px green-circle / inline white-check SVG in the top-left corner of selected cards, mirroring the X button at top-right. Renders on both desktop and mobile. `pointer-events: none` so the card body underneath still toggles off.

## Test plan

- [ ] Add 2 same-category items in sequence (e.g. two pairs of pants). Confirm the second tap silently swaps — old card returns to unselected, new card becomes selected.
- [ ] At MAX_OUTFIT_ITEMS (4 items), tap a same-category replacement. Confirm the swap still works.
- [ ] Cross-group conflicts still disable cards (e.g. excludes-listed pairings, same-group-exclusive without includes-override).
- [ ] Desktop: selected cards visibly reorder to the front of each rail; non-selected items keep backend order.
- [ ] Mobile: no reordering — selecting an item leaves it in place.
- [ ] Green badge with white checkmark in top-left of every selected card, both layouts. Tapping the badge area still toggles selection off (pointer-events transparent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)