### PR TITLE
Fitting-room: toggle, trash remove, first-view tooltips, add-confirmation drawer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,45 @@ metaobject, both fields come through `null` and `ColorSwatchRow` falls
 through image → hex → text-label rendering. See `shopify/AGENTS.md` →
 "Colour swatches (Storefront API token)" for the merchant-side setup.
 
+## Fitting-room icon widget — three responsibilities
+
+`src/components/widgets/fitting-room-icon.tsx` is no longer just the
+header icon. It also hosts two anchored popovers that need to live next
+to the icon:
+
+- **First-visit tooltip** (`first-visit-tooltip.tsx`) — fires once per
+  browser the first time the widget mounts. Dismiss paths (icon click,
+  tooltip close, click-outside) all write the localStorage flag
+  `tfr:first-visit-tooltip-seen:v1`, a sibling to the existing
+  `tfr:fitting-room:v1`. While showing, the icon button gets a soft
+  green pulsing box-shadow.
+- **Add-confirmation drawer** (`add-confirmation-drawer.tsx`) — fires
+  whenever any item is added to the fitting room from any surface
+  (catalog hanger, PDP, quick-view). Auto-dismisses after 4s; click-
+  outside also dismisses. Items inside use a trash icon for remove
+  (calls `removeFromFittingRoom`); CTA opens the overlay.
+
+### `lastAddEvent` — the cross-widget signal
+
+The drawer is owned by the icon widget but fires in response to adds
+that happen elsewhere (a separate `add-to-fitting-room-compact` widget
+on catalog cards, a PDP widget, etc). They cannot call each other
+directly. The signal funnels through `useMainStore`:
+
+```ts
+lastAddEvent: { externalId: string; at: number } | null
+setLastAddEvent: (externalId: string) => void
+```
+
+Written by `addFittingRoomItem` in `fitting-room-storage.ts` (the
+single funnel for all add paths). The icon widget subscribes; the `at`
+timestamp lets re-adds of the same `externalId` re-fire (object
+reference changes on every add). Not persisted to localStorage.
+
+This is the canonical pattern for transient cross-widget signals — if
+you need another one, use the same `{ id, at }` shape so subscribers
+can dep on the whole object.
+
 ---
 
 ## Definition of done

--- a/src/assets/trash-icon.svg
+++ b/src/assets/trash-icon.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2.5 4H13.5" stroke="#21201F" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M6 4V2.5C6 2.22386 6.22386 2 6.5 2H9.5C9.77614 2 10 2.22386 10 2.5V4" stroke="#21201F" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M3.5 4V13C3.5 13.5523 3.94772 14 4.5 14H11.5C12.0523 14 12.5 13.5523 12.5 13V4" stroke="#21201F" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 7V11" stroke="#21201F" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M9.5 7V11" stroke="#21201F" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/overlays/fitting-room/avatar-controls.tsx
+++ b/src/components/overlays/fitting-room/avatar-controls.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/button'
 import { Text } from '@/components/text'
-import { SelectedItemsIcon, TuckIcon, ZoomIcon } from '@/lib/asset'
+import { SelectedItemsIcon, TrashIcon, TuckIcon, ZoomIcon } from '@/lib/asset'
 import type { ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
 import { useTranslation } from '@/lib/locale'
 import type { CssProp, ThemeData } from '@/lib/theme'
@@ -160,7 +160,14 @@ export function AvatarControls({
       border: 'none',
       backgroundColor: 'transparent',
       cursor: 'pointer',
-      fontSize: '14px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 0,
+    },
+    popoverRemoveIcon: {
+      width: '14px',
+      height: '14px',
     },
   }))
 
@@ -197,7 +204,7 @@ export function AvatarControls({
                   {item.merchantProduct?.productName ?? item.externalId}
                 </Text>
                 <button css={css.popoverRemove} onClick={() => onRemoveItem(item.externalId)} aria-label="Remove">
-                  ×
+                  <TrashIcon css={css.popoverRemoveIcon} />
                 </button>
               </div>
             ))

--- a/src/components/overlays/fitting-room/card-checkbox.tsx
+++ b/src/components/overlays/fitting-room/card-checkbox.tsx
@@ -1,0 +1,82 @@
+import type { MouseEvent } from 'react'
+import { useCss } from '@/lib/theme'
+
+interface CardCheckboxProps {
+  state: 'selected' | 'unselected' | 'disabled'
+  onClick?: () => void
+  ariaLabel?: string
+}
+
+// Three-state visual checkbox on every fitting-room rail card. Mirrors the
+// removeButton geometry (top-left, ~22px square). The card body is still the
+// primary toggle; this gives the affordance an obvious shape AND a redundant
+// click target. Stops propagation so it doesn't double-fire the body.
+//
+// Explicit grey palette on the disabled state so the affordance still reads
+// through the container's `opacity: 0.35` dim.
+export function CardCheckbox({ state, onClick, ariaLabel }: CardCheckboxProps) {
+  const css = useCss((theme) => ({
+    base: {
+      position: 'absolute',
+      top: '8px',
+      left: '8px',
+      width: '22px',
+      height: '22px',
+      borderRadius: '4px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 0,
+      zIndex: 1,
+    },
+    unselected: {
+      backgroundColor: '#FFFFFF',
+      border: `1.5px solid ${theme.color_fg_text}`,
+      cursor: 'pointer',
+    },
+    selected: {
+      backgroundColor: '#22C55E',
+      border: 'none',
+      cursor: 'pointer',
+    },
+    disabled: {
+      backgroundColor: '#E5E5E5',
+      border: '1.5px solid #B5B5B5',
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
+    },
+  }))
+
+  const variantCss = state === 'selected' ? css.selected : state === 'disabled' ? css.disabled : css.unselected
+
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation()
+    if (state === 'disabled' || !onClick) {
+      return
+    }
+    onClick()
+  }
+
+  return (
+    <button
+      type="button"
+      css={{ ...css.base, ...variantCss }}
+      onClick={handleClick}
+      aria-pressed={state === 'selected'}
+      aria-disabled={state === 'disabled'}
+      aria-label={ariaLabel}
+    >
+      {state === 'selected' ? (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M3 8.5L6.5 12L13 4.5"
+            stroke="#FFFFFF"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+    </button>
+  )
+}

--- a/src/components/overlays/fitting-room/card-checkbox.tsx
+++ b/src/components/overlays/fitting-room/card-checkbox.tsx
@@ -7,47 +7,61 @@ interface CardCheckboxProps {
   ariaLabel?: string
 }
 
-// Three-state visual checkbox on every fitting-room rail card. Mirrors the
-// removeButton geometry (top-left, ~22px square). The card body is still the
-// primary toggle; this gives the affordance an obvious shape AND a redundant
-// click target. Stops propagation so it doesn't double-fire the body.
+// Toggle-pill control on every fitting-room rail card. Top-left anchor.
+// The card body is still the primary toggle; this is an explicit visual
+// affordance + a redundant click target. Stops propagation so it doesn't
+// double-fire the body.
 //
-// Explicit grey palette on the disabled state so the affordance still reads
-// through the container's `opacity: 0.35` dim.
+// Track: 36×20 pill. Thumb: 16×16 circle that slides between left and right
+// ends. Off = grey track. On = green track. Disabled = greyed, thumb stays
+// at the off position.
 export function CardCheckbox({ state, onClick, ariaLabel }: CardCheckboxProps) {
   const css = useCss((theme) => ({
     base: {
       position: 'absolute',
       top: '8px',
       left: '8px',
-      width: '22px',
-      height: '22px',
-      borderRadius: '4px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
+      width: '36px',
+      height: '20px',
+      borderRadius: '10px',
+      border: 'none',
       padding: 0,
       zIndex: 1,
+      transition: 'background-color 150ms ease-out',
     },
     unselected: {
-      backgroundColor: '#FFFFFF',
-      border: `1.5px solid ${theme.color_fg_text}`,
+      backgroundColor: '#D4D4D4',
       cursor: 'pointer',
     },
     selected: {
-      backgroundColor: '#22C55E',
-      border: 'none',
+      backgroundColor: theme.color_tfr_800,
       cursor: 'pointer',
     },
     disabled: {
-      backgroundColor: '#E5E5E5',
-      border: '1.5px solid #B5B5B5',
+      backgroundColor: '#EAEAEA',
       cursor: 'not-allowed',
       pointerEvents: 'none',
     },
+    thumb: {
+      position: 'absolute',
+      top: '2px',
+      width: '16px',
+      height: '16px',
+      borderRadius: '8px',
+      backgroundColor: '#FFFFFF',
+      boxShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
+      transition: 'left 150ms ease-out',
+    },
+    thumbOff: {
+      left: '2px',
+    },
+    thumbOn: {
+      left: '18px',
+    },
   }))
 
-  const variantCss = state === 'selected' ? css.selected : state === 'disabled' ? css.disabled : css.unselected
+  const trackCss = state === 'selected' ? css.selected : state === 'disabled' ? css.disabled : css.unselected
+  const thumbPosCss = state === 'selected' ? css.thumbOn : css.thumbOff
 
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation()
@@ -60,23 +74,13 @@ export function CardCheckbox({ state, onClick, ariaLabel }: CardCheckboxProps) {
   return (
     <button
       type="button"
-      css={{ ...css.base, ...variantCss }}
+      css={{ ...css.base, ...trackCss }}
       onClick={handleClick}
       aria-pressed={state === 'selected'}
       aria-disabled={state === 'disabled'}
       aria-label={ariaLabel}
     >
-      {state === 'selected' ? (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M3 8.5L6.5 12L13 4.5"
-            stroke="#FFFFFF"
-            strokeWidth="2.2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      ) : null}
+      <span css={{ ...css.thumb, ...thumbPosCss }} />
     </button>
   )
 }

--- a/src/components/overlays/fitting-room/card-rail.tsx
+++ b/src/components/overlays/fitting-room/card-rail.tsx
@@ -109,7 +109,7 @@ export function CardRail({
     horizontal: {
       display: 'flex',
       flexDirection: 'row',
-      gap: '8px',
+      gap: '16px',
       overflowX: 'auto',
       padding: '4px 0',
       // Native scrollbar hidden — the chevron handles are the affordance.

--- a/src/components/overlays/fitting-room/product-card.tsx
+++ b/src/components/overlays/fitting-room/product-card.tsx
@@ -40,7 +40,7 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
       textAlign: 'left',
     },
     containerSelected: {
-      borderColor: '#16A34A',
+      borderColor: theme.color_tfr_800,
     },
     containerDisabled: {
       opacity: 0.35,

--- a/src/components/overlays/fitting-room/product-card.tsx
+++ b/src/components/overlays/fitting-room/product-card.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react'
 import { Button } from '@/components/button'
 import { Text } from '@/components/text'
-import { CloseIcon } from '@/lib/asset'
+import { TrashIcon } from '@/lib/asset'
 import type { ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
+import { useTranslation } from '@/lib/locale'
 import { useCss } from '@/lib/theme'
 import type { Availability } from '@/lib/fitting-room-outfit'
+import { CardCheckbox } from './card-checkbox'
 import { ColorSwatchRow, type ColorSwatchEntry } from './color-swatch-row'
 
 interface ProductCardProps {
@@ -22,6 +24,7 @@ interface ProductCardProps {
 // the border (selected → solid border) and disabled treatment (greyed +
 // non-clickable when other selections rule this one out).
 export function ProductCard({ item, availability, onClick, onRemove, onChangeColor }: ProductCardProps) {
+  const { t } = useTranslation()
   const css = useCss((theme) => ({
     container: {
       position: 'relative',
@@ -30,13 +33,14 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
       display: 'flex',
       flexDirection: 'column',
       gap: '8px',
-      padding: '8px',
-      border: '1px solid transparent',
+      padding: '12px 20px',
+      border: '1.5px solid #E0E0E0',
+      borderRadius: '8px',
       backgroundColor: 'transparent',
       textAlign: 'left',
     },
     containerSelected: {
-      border: `1px solid ${theme.color_fg_text}`,
+      borderColor: '#16A34A',
     },
     containerDisabled: {
       opacity: 0.35,
@@ -77,8 +81,8 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
     },
     removeButton: {
       position: 'absolute',
-      top: '4px',
-      right: '4px',
+      top: '8px',
+      right: '8px',
       width: '24px',
       height: '24px',
       borderRadius: '12px',
@@ -92,26 +96,8 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
       zIndex: 1,
     },
     removeIcon: {
-      width: '12px',
-      height: '12px',
-    },
-    // Selected badge — mirrors the X button at the top-right, green-filled
-    // circle at top-left with an inline white checkmark. Only rendered when
-    // availability === 'selected'. Decorative: pointer-events: none so the
-    // shopper still taps the card body underneath to toggle off.
-    selectedBadge: {
-      position: 'absolute',
-      top: '4px',
-      left: '4px',
-      width: '24px',
-      height: '24px',
-      borderRadius: '12px',
-      backgroundColor: '#22C55E',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      pointerEvents: 'none',
-      zIndex: 1,
+      width: '14px',
+      height: '14px',
     },
   }))
 
@@ -200,21 +186,13 @@ export function ProductCard({ item, availability, onClick, onRemove, onChangeCol
         }}
         aria-label="Remove from fitting room"
       >
-        <CloseIcon css={css.removeIcon} />
+        <TrashIcon css={css.removeIcon} />
       </button>
-      {selected ? (
-        <div css={css.selectedBadge} aria-hidden="true">
-          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M3 8.5L6.5 12L13 4.5"
-              stroke="#FFFFFF"
-              strokeWidth="2.2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </div>
-      ) : null}
+      <CardCheckbox
+        state={disabled ? 'disabled' : selected ? 'selected' : 'unselected'}
+        onClick={handleClick}
+        ariaLabel={t('fitting_room.toggle_selection')}
+      />
       <Button
         variant="base"
         css={{

--- a/src/components/widgets/add-confirmation-drawer.tsx
+++ b/src/components/widgets/add-confirmation-drawer.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react'
 import { Button } from '@/components/button'
 import { Text } from '@/components/text'
-import { CloseIcon, TrashIcon } from '@/lib/asset'
+import { TrashIcon } from '@/lib/asset'
+import { loadMerchantProductData } from '@/lib/fitting-room-data'
 import { useTranslation } from '@/lib/locale'
 import { useMainStore } from '@/lib/store'
 import { useCss } from '@/lib/theme'
@@ -8,78 +10,102 @@ import { useCss } from '@/lib/theme'
 interface AddConfirmationDrawerProps {
   onDismiss: () => void
   onOpenOverlay: () => void
+  // Called the first time the shopper interacts with the drawer (hover,
+  // pointer, focus). The parent cancels its auto-dismiss timer so engaged
+  // shoppers don't have it close out from under them.
+  onInteract: () => void
 }
+
+// Arrow geometry mirrors the first-visit tooltip. Drawer is right-anchored
+// to the icon, so the arrow's horizontal position is fixed relative to the
+// drawer's right edge: icon centre is 22px from drawer right (icon is 44px
+// wide, drawer aligns to icon's right edge); the 32px-wide arrow sits 6px
+// from the drawer's right edge so its centre lines up with the icon.
+const ARROW_WIDTH = 32
+const ARROW_HEIGHT = 16
+const ARROW_RIGHT = 6
 
 // Mini-drawer anchored beneath the fitting-room icon. Fires when an item is
 // added (via the lastAddEvent store signal — see fitting-room-icon.tsx).
 // Flat structure: title row, subheader, item list, CTA. No collapsibles.
 // Auto-dismiss and click-outside are handled by the parent.
-export function AddConfirmationDrawer({ onDismiss, onOpenOverlay }: AddConfirmationDrawerProps) {
+export function AddConfirmationDrawer({ onDismiss, onOpenOverlay, onInteract }: AddConfirmationDrawerProps) {
   const { t } = useTranslation()
   const fittingRoom = useMainStore((state) => state.fittingRoom)
   const merchantProductData = useMainStore((state) => state.merchantProductData)
   const removeFromFittingRoom = useMainStore((state) => state.removeFromFittingRoom)
 
+  // Trigger merchant productLookup on mount for any items not already in the
+  // store cache. The drawer fires before the fitting-room overlay opens (the
+  // overlay's loadFittingRoomData is normally what populates this), so for a
+  // freshly-added item the drawer would otherwise show just the externalId.
+  useEffect(() => {
+    void loadMerchantProductData(fittingRoom)
+    // Run once per fittingRoom identity change (each add gives a new array).
+  }, [fittingRoom])
+
   const css = useCss((theme) => ({
-    drawer: {
+    wrapper: {
       position: 'absolute',
       top: '100%',
       right: 0,
-      marginTop: '12px',
+      marginTop: `${ARROW_HEIGHT}px`,
       width: '320px',
-      maxHeight: '480px',
-      backgroundColor: '#FFFFFF',
-      border: `1px solid ${theme.color_fg_text}`,
-      borderRadius: '8px',
-      boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
-      display: 'flex',
-      flexDirection: 'column',
-      overflow: 'hidden',
       zIndex: 2147483646,
       fontFamily: theme.font_family,
     },
     arrow: {
       position: 'absolute',
-      top: '-7px',
-      right: '14px',
-      width: 0,
-      height: 0,
-      borderLeft: '8px solid transparent',
-      borderRight: '8px solid transparent',
-      borderBottom: `8px solid ${theme.color_fg_text}`,
+      top: `-${ARROW_HEIGHT - 1}px`,
+      right: `${ARROW_RIGHT}px`,
+      width: `${ARROW_WIDTH}px`,
+      height: `${ARROW_HEIGHT}px`,
+      color: theme.color_tfr_800,
+      pointerEvents: 'none',
     },
-    headerRow: {
+    drawer: {
+      width: '100%',
+      maxHeight: '480px',
+      backgroundColor: '#FFFFFF',
+      border: `3px solid ${theme.color_tfr_800}`,
+      borderRadius: '8px',
+      boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
       display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      padding: '12px 14px',
-      borderBottom: `1px solid ${theme.color_fg_text}`,
+      flexDirection: 'column',
+      overflow: 'hidden',
+    },
+    header: {
+      position: 'relative',
+      padding: '12px 40px',
+      borderBottom: `1px solid rgba(0, 0, 0, 0.1)`,
     },
     title: {
       fontSize: '14px',
       fontWeight: 'bold',
+      textAlign: 'center',
     },
     closeBtn: {
+      position: 'absolute',
+      top: '8px',
+      right: '8px',
       width: '24px',
       height: '24px',
       borderRadius: '12px',
       border: 'none',
       backgroundColor: 'transparent',
+      color: theme.color_fg_text,
       cursor: 'pointer',
       padding: 0,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
     },
-    closeIcon: {
-      width: '12px',
-      height: '12px',
-    },
     subheader: {
       padding: '10px 14px',
       fontSize: '12px',
       color: theme.color_fg_text,
       backgroundColor: '#F4F4F4',
+      textAlign: 'center',
     },
     list: {
       overflowY: 'auto',
@@ -139,68 +165,82 @@ export function AddConfirmationDrawer({ onDismiss, onOpenOverlay }: AddConfirmat
     },
     ctaWrapper: {
       padding: '12px 14px',
-      borderTop: `1px solid ${theme.color_fg_text}`,
+      borderTop: `1px solid rgba(0, 0, 0, 0.1)`,
     },
   }))
 
   return (
-    <div css={css.drawer} role="dialog" aria-label={t('add_confirmation.title')}>
-      <div css={css.arrow} />
-      <div css={css.headerRow}>
-        <Text variant="base" css={css.title}>
-          {t('add_confirmation.title')}
+    <div
+      css={css.wrapper}
+      role="dialog"
+      aria-label={t('add_confirmation.title')}
+      onMouseEnter={onInteract}
+      onPointerDown={onInteract}
+      onFocus={onInteract}
+    >
+      <svg
+        css={css.arrow}
+        viewBox={`0 0 ${ARROW_WIDTH} ${ARROW_HEIGHT}`}
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <polygon points={`0,${ARROW_HEIGHT} ${ARROW_WIDTH / 2},0 ${ARROW_WIDTH},${ARROW_HEIGHT}`} fill="currentColor" />
+      </svg>
+      <div css={css.drawer}>
+        <div css={css.header}>
+          <Text variant="base" css={css.title}>
+            {t('add_confirmation.title')}
+          </Text>
+          <button css={css.closeBtn} onClick={onDismiss} aria-label={t('add_confirmation.dismiss')}>
+            <svg width="12" height="12" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+        <Text variant="base" css={css.subheader}>
+          {t('add_confirmation.added_header')}
         </Text>
-        <button css={css.closeBtn} onClick={onDismiss} aria-label={t('add_confirmation.dismiss')}>
-          <CloseIcon css={css.closeIcon} />
-        </button>
-      </div>
-      <Text variant="base" css={css.subheader}>
-        {t('add_confirmation.added_header')}
-      </Text>
-      <div css={css.list}>
-        {fittingRoom.map((item) => {
-          const merchant = merchantProductData[item.externalId]
-          const product = merchant && !('error' in merchant) ? merchant : null
-          // Best-effort variant match: prefer (color, size); fall back to
-          // (color, any size); fall back to the product's featured image.
-          // The drawer renders before the overlay has populated size/color
-          // for fresh-from-catalog adds, so the fallbacks must work.
-          const variant =
-            product?.variants.find((v) => v.color === item.color && (!item.size || v.size === item.size)) ??
-            product?.variants.find((v) => v.color === item.color) ??
-            null
-          const imageUrl = variant?.imageUrl ?? product?.imageUrl ?? null
-          const name = product?.productName ?? item.externalId
-          const price = variant?.priceFormatted ?? product?.variants[0]?.priceFormatted ?? null
-          const metaParts = [item.color, price].filter(Boolean)
-          return (
-            <div css={css.item} key={item.externalId}>
-              {imageUrl ? <img src={imageUrl} css={css.thumb} alt="" /> : <div css={css.thumb} />}
-              <div css={css.itemBody}>
-                <Text variant="base" css={css.itemName}>
-                  {name}
-                </Text>
-                {metaParts.length > 0 ? (
-                  <Text variant="base" css={css.itemMeta}>
-                    {metaParts.join(' · ')}
+        <div css={css.list}>
+          {fittingRoom.map((item) => {
+            const merchant = merchantProductData[item.externalId]
+            const product = merchant && !('error' in merchant) ? merchant : null
+            const variant =
+              product?.variants.find((v) => v.color === item.color && (!item.size || v.size === item.size)) ??
+              product?.variants.find((v) => v.color === item.color) ??
+              null
+            const imageUrl = variant?.imageUrl ?? product?.imageUrl ?? null
+            const name = product?.productName ?? item.externalId
+            const price = variant?.priceFormatted ?? product?.variants[0]?.priceFormatted ?? null
+            const metaParts = [item.color, price].filter(Boolean)
+            return (
+              <div css={css.item} key={item.externalId}>
+                {imageUrl ? <img src={imageUrl} css={css.thumb} alt="" /> : <div css={css.thumb} />}
+                <div css={css.itemBody}>
+                  <Text variant="base" css={css.itemName}>
+                    {name}
                   </Text>
-                ) : null}
+                  {metaParts.length > 0 ? (
+                    <Text variant="base" css={css.itemMeta}>
+                      {metaParts.join(' · ')}
+                    </Text>
+                  ) : null}
+                </div>
+                <button
+                  css={css.removeBtn}
+                  onClick={() => removeFromFittingRoom(item.externalId)}
+                  aria-label={t('add_confirmation.remove')}
+                >
+                  <TrashIcon css={css.removeIcon} />
+                </button>
               </div>
-              <button
-                css={css.removeBtn}
-                onClick={() => removeFromFittingRoom(item.externalId)}
-                aria-label={t('add_confirmation.remove')}
-              >
-                <TrashIcon css={css.removeIcon} />
-              </button>
-            </div>
-          )
-        })}
-      </div>
-      <div css={css.ctaWrapper}>
-        <Button variant="primary" onClick={onOpenOverlay}>
-          {t('add_confirmation.cta')}
-        </Button>
+            )
+          })}
+        </div>
+        <div css={css.ctaWrapper}>
+          <Button variant="primary" onClick={onOpenOverlay}>
+            {t('add_confirmation.cta')}
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/src/components/widgets/add-confirmation-drawer.tsx
+++ b/src/components/widgets/add-confirmation-drawer.tsx
@@ -1,0 +1,207 @@
+import { Button } from '@/components/button'
+import { Text } from '@/components/text'
+import { CloseIcon, TrashIcon } from '@/lib/asset'
+import { useTranslation } from '@/lib/locale'
+import { useMainStore } from '@/lib/store'
+import { useCss } from '@/lib/theme'
+
+interface AddConfirmationDrawerProps {
+  onDismiss: () => void
+  onOpenOverlay: () => void
+}
+
+// Mini-drawer anchored beneath the fitting-room icon. Fires when an item is
+// added (via the lastAddEvent store signal — see fitting-room-icon.tsx).
+// Flat structure: title row, subheader, item list, CTA. No collapsibles.
+// Auto-dismiss and click-outside are handled by the parent.
+export function AddConfirmationDrawer({ onDismiss, onOpenOverlay }: AddConfirmationDrawerProps) {
+  const { t } = useTranslation()
+  const fittingRoom = useMainStore((state) => state.fittingRoom)
+  const merchantProductData = useMainStore((state) => state.merchantProductData)
+  const removeFromFittingRoom = useMainStore((state) => state.removeFromFittingRoom)
+
+  const css = useCss((theme) => ({
+    drawer: {
+      position: 'absolute',
+      top: '100%',
+      right: 0,
+      marginTop: '12px',
+      width: '320px',
+      maxHeight: '480px',
+      backgroundColor: '#FFFFFF',
+      border: `1px solid ${theme.color_fg_text}`,
+      borderRadius: '8px',
+      boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+      zIndex: 2147483646,
+      fontFamily: theme.font_family,
+    },
+    arrow: {
+      position: 'absolute',
+      top: '-7px',
+      right: '14px',
+      width: 0,
+      height: 0,
+      borderLeft: '8px solid transparent',
+      borderRight: '8px solid transparent',
+      borderBottom: `8px solid ${theme.color_fg_text}`,
+    },
+    headerRow: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: '12px 14px',
+      borderBottom: `1px solid ${theme.color_fg_text}`,
+    },
+    title: {
+      fontSize: '14px',
+      fontWeight: 'bold',
+    },
+    closeBtn: {
+      width: '24px',
+      height: '24px',
+      borderRadius: '12px',
+      border: 'none',
+      backgroundColor: 'transparent',
+      cursor: 'pointer',
+      padding: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    closeIcon: {
+      width: '12px',
+      height: '12px',
+    },
+    subheader: {
+      padding: '10px 14px',
+      fontSize: '12px',
+      color: theme.color_fg_text,
+      backgroundColor: '#F4F4F4',
+    },
+    list: {
+      overflowY: 'auto',
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    item: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '10px',
+      padding: '10px 14px',
+      borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
+    },
+    thumb: {
+      width: '48px',
+      height: '60px',
+      backgroundColor: '#F4F4F4',
+      flex: 'none',
+      objectFit: 'cover',
+    },
+    itemBody: {
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+      minWidth: 0,
+    },
+    itemName: {
+      fontSize: '13px',
+      lineHeight: '1.3',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    itemMeta: {
+      fontSize: '12px',
+      color: theme.color_fg_text,
+      opacity: 0.7,
+    },
+    removeBtn: {
+      width: '32px',
+      height: '32px',
+      borderRadius: '16px',
+      border: 'none',
+      backgroundColor: 'transparent',
+      cursor: 'pointer',
+      padding: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 'none',
+    },
+    removeIcon: {
+      width: '16px',
+      height: '16px',
+    },
+    ctaWrapper: {
+      padding: '12px 14px',
+      borderTop: `1px solid ${theme.color_fg_text}`,
+    },
+  }))
+
+  return (
+    <div css={css.drawer} role="dialog" aria-label={t('add_confirmation.title')}>
+      <div css={css.arrow} />
+      <div css={css.headerRow}>
+        <Text variant="base" css={css.title}>
+          {t('add_confirmation.title')}
+        </Text>
+        <button css={css.closeBtn} onClick={onDismiss} aria-label={t('add_confirmation.dismiss')}>
+          <CloseIcon css={css.closeIcon} />
+        </button>
+      </div>
+      <Text variant="base" css={css.subheader}>
+        {t('add_confirmation.added_header')}
+      </Text>
+      <div css={css.list}>
+        {fittingRoom.map((item) => {
+          const merchant = merchantProductData[item.externalId]
+          const product = merchant && !('error' in merchant) ? merchant : null
+          // Best-effort variant match: prefer (color, size); fall back to
+          // (color, any size); fall back to the product's featured image.
+          // The drawer renders before the overlay has populated size/color
+          // for fresh-from-catalog adds, so the fallbacks must work.
+          const variant =
+            product?.variants.find((v) => v.color === item.color && (!item.size || v.size === item.size)) ??
+            product?.variants.find((v) => v.color === item.color) ??
+            null
+          const imageUrl = variant?.imageUrl ?? product?.imageUrl ?? null
+          const name = product?.productName ?? item.externalId
+          const price = variant?.priceFormatted ?? product?.variants[0]?.priceFormatted ?? null
+          const metaParts = [item.color, price].filter(Boolean)
+          return (
+            <div css={css.item} key={item.externalId}>
+              {imageUrl ? <img src={imageUrl} css={css.thumb} alt="" /> : <div css={css.thumb} />}
+              <div css={css.itemBody}>
+                <Text variant="base" css={css.itemName}>
+                  {name}
+                </Text>
+                {metaParts.length > 0 ? (
+                  <Text variant="base" css={css.itemMeta}>
+                    {metaParts.join(' · ')}
+                  </Text>
+                ) : null}
+              </div>
+              <button
+                css={css.removeBtn}
+                onClick={() => removeFromFittingRoom(item.externalId)}
+                aria-label={t('add_confirmation.remove')}
+              >
+                <TrashIcon css={css.removeIcon} />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+      <div css={css.ctaWrapper}>
+        <Button variant="primary" onClick={onOpenOverlay}>
+          {t('add_confirmation.cta')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/add-to-fitting-room-compact.tsx
+++ b/src/components/widgets/add-to-fitting-room-compact.tsx
@@ -1,3 +1,5 @@
+import { keyframes } from '@emotion/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FittingRoomIcon } from '@/lib/asset'
 import { toggleFittingRoomItem } from '@/lib/fitting-room-storage'
 import { useTranslation } from '@/lib/locale'
@@ -5,8 +7,26 @@ import { getLogger } from '@/lib/logger'
 import { getStaticData, useMainStore } from '@/lib/store'
 import { useCss } from '@/lib/theme'
 import type { WidgetProps } from '@/lib/view'
+import { FirstVisitTooltip } from './first-visit-tooltip'
 
 const logger = getLogger('widgets/add-to-fitting-room-compact')
+
+const FIRST_ADD_KEY = 'tfr:first-add-tooltip-seen:v1'
+const TOOLTIP_AUTO_DISMISS_MS = 10000
+
+// Module-level claim: catalog pages render N of these widgets (one per
+// product card). Only the first instance to mount on a page run should
+// surface the first-add tooltip — without this guard every card would race
+// to show its own. Resets per SDK init (per page navigation).
+let firstAddTooltipClaimed = false
+
+// Soft teal box-shadow pulse — only animates while the first-add tooltip
+// is showing. Matches the pulse on the header fitting-room icon.
+const pulse = keyframes`
+  0%   { box-shadow: 0 0 0 0 rgba(38, 90, 100, 0.6); }
+  70%  { box-shadow: 0 0 0 10px rgba(38, 90, 100, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(38, 90, 100, 0); }
+`
 
 export default function AddToFittingRoomCompactWidget({ attributes }: WidgetProps) {
   const { t } = useTranslation()
@@ -21,7 +41,65 @@ export default function AddToFittingRoomCompactWidget({ attributes }: WidgetProp
     productId == null ? false : state.fittingRoom.some((item) => item.externalId === productId),
   )
 
+  const [showTooltip, setShowTooltip] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // Claim + show on first mount, only if no prior widget has already claimed
+  // in this SDK lifetime and the localStorage flag isn't set.
+  useEffect(() => {
+    if (firstAddTooltipClaimed) {
+      return
+    }
+    try {
+      if (window.localStorage.getItem(FIRST_ADD_KEY)) {
+        return
+      }
+    } catch (error) {
+      logger.logWarn('Failed to read first-add tooltip flag', { error })
+      return
+    }
+    firstAddTooltipClaimed = true
+    setShowTooltip(true)
+  }, [])
+
+  const dismissTooltip = useCallback(() => {
+    setShowTooltip(false)
+    try {
+      window.localStorage.setItem(FIRST_ADD_KEY, 'true')
+    } catch (error) {
+      logger.logWarn('Failed to write first-add tooltip flag', { error })
+    }
+  }, [])
+
+  // Auto-dismiss after 10s.
+  useEffect(() => {
+    if (!showTooltip) {
+      return
+    }
+    const timer = window.setTimeout(dismissTooltip, TOOLTIP_AUTO_DISMISS_MS)
+    return () => window.clearTimeout(timer)
+  }, [showTooltip, dismissTooltip])
+
+  // Click-outside dismisses too.
+  useEffect(() => {
+    if (!showTooltip) {
+      return
+    }
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        dismissTooltip()
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [showTooltip, dismissTooltip])
+
   const css = useCss((theme) => ({
+    wrapper: {
+      position: 'relative',
+      display: 'inline-block',
+    },
     button: {
       display: 'inline-flex',
       alignItems: 'center',
@@ -36,6 +114,9 @@ export default function AddToFittingRoomCompactWidget({ attributes }: WidgetProp
     },
     buttonAdded: {
       backgroundColor: theme.color_fg_text,
+    },
+    buttonPulsing: {
+      animation: `${pulse} 1.8s ease-out infinite`,
     },
     icon: {
       width: '24px',
@@ -52,6 +133,9 @@ export default function AddToFittingRoomCompactWidget({ attributes }: WidgetProp
   }
 
   const handleClick = () => {
+    if (showTooltip) {
+      dismissTooltip()
+    }
     toggleFittingRoomItem(productId, productHandle, isPdp).catch((error) => {
       logger.logError('toggleFittingRoomItem failed', { error })
     })
@@ -60,14 +144,25 @@ export default function AddToFittingRoomCompactWidget({ attributes }: WidgetProp
   const ariaLabel = t(isInFittingRoom ? 'added_to_fitting_room' : 'add_to_fitting_room')
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      css={[css.button, isInFittingRoom && css.buttonAdded]}
-      aria-label={ariaLabel}
-      aria-pressed={isInFittingRoom}
-    >
-      <FittingRoomIcon css={[css.icon, isInFittingRoom && css.iconAdded]} />
-    </button>
+    <div ref={wrapperRef} css={css.wrapper}>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleClick}
+        css={[css.button, isInFittingRoom && css.buttonAdded, showTooltip && css.buttonPulsing]}
+        aria-label={ariaLabel}
+        aria-pressed={isInFittingRoom}
+      >
+        <FittingRoomIcon css={[css.icon, isInFittingRoom && css.iconAdded]} />
+      </button>
+      {showTooltip ? (
+        <FirstVisitTooltip
+          text={t('first_add_tooltip.body')}
+          dismissAriaLabel={t('first_add_tooltip.dismiss')}
+          onDismiss={dismissTooltip}
+          anchorRef={buttonRef}
+        />
+      ) : null}
+    </div>
   )
 }

--- a/src/components/widgets/first-visit-tooltip.tsx
+++ b/src/components/widgets/first-visit-tooltip.tsx
@@ -1,10 +1,11 @@
 import type { RefObject } from 'react'
 import { useEffect, useState } from 'react'
 import { Text } from '@/components/text'
-import { useTranslation } from '@/lib/locale'
 import { useCss } from '@/lib/theme'
 
 interface FirstVisitTooltipProps {
+  text: string
+  dismissAriaLabel: string
   onDismiss: () => void
   anchorRef: RefObject<HTMLElement | null>
 }
@@ -15,16 +16,16 @@ const ARROW_WIDTH = 32
 const ARROW_HEIGHT = 16
 const ARROW_GAP = 14
 
-// Tooltip anchored beneath the fitting-room icon, shown once per browser
-// (first time the icon mounts; dismissed by click on icon, close button, or
-// click outside — see fitting-room-icon.tsx for the dismiss wiring).
+// Tooltip anchored beneath an arbitrary element (passed via anchorRef),
+// shown once per browser. Dismiss + first-view bookkeeping lives in the
+// consumer (e.g. fitting-room-icon.tsx for the header icon,
+// add-to-fitting-room-compact.tsx for the hanger).
 //
-// Positioned with `position: fixed` against the icon's screen rect so we can
-// horizontally centre the tooltip under the icon, then clamp to keep both
+// Positioned with `position: fixed` against the anchor's screen rect so we
+// can horizontally centre the tooltip under it, then clamp to keep both
 // edges inside the viewport with a small padding. The arrow then re-anchors
-// to the icon's centre regardless of where the tooltip ended up.
-export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipProps) {
-  const { t } = useTranslation()
+// to the anchor's centre regardless of where the tooltip ended up.
+export function FirstVisitTooltip({ text, dismissAriaLabel, onDismiss, anchorRef }: FirstVisitTooltipProps) {
   const [pos, setPos] = useState<{ left: number; top: number; arrowLeft: number } | null>(null)
 
   useEffect(() => {
@@ -75,20 +76,22 @@ export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipPro
       pointerEvents: 'none',
     },
     body: {
-      backgroundColor: theme.color_tfr_800,
-      color: '#FFFFFF',
-      padding: '12px 14px',
+      backgroundColor: '#FFFFFF',
+      color: theme.color_tfr_800,
+      border: `2px solid ${theme.color_tfr_800}`,
+      padding: '6px 10px',
       borderRadius: '8px',
       boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
       display: 'flex',
-      alignItems: 'flex-start',
-      gap: '4px',
+      alignItems: 'center',
+      gap: 0,
     },
     text: {
       flex: 1,
       fontSize: '13px',
       lineHeight: '1.4',
-      color: '#FFFFFF',
+      color: theme.color_tfr_800,
+      textAlign: 'center',
     },
     closeBtn: {
       width: '20px',
@@ -96,7 +99,7 @@ export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipPro
       borderRadius: '10px',
       border: 'none',
       backgroundColor: 'transparent',
-      color: '#F0F0F0',
+      color: theme.color_tfr_800,
       cursor: 'pointer',
       padding: 0,
       display: 'flex',
@@ -111,12 +114,7 @@ export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipPro
   }
 
   return (
-    <div
-      css={css.wrapper}
-      style={{ left: `${pos.left}px`, top: `${pos.top}px` }}
-      role="dialog"
-      aria-label={t('first_visit_tooltip.body')}
-    >
+    <div css={css.wrapper} style={{ left: `${pos.left}px`, top: `${pos.top}px` }} role="dialog" aria-label={text}>
       <svg
         css={css.arrow}
         style={{ left: `${pos.arrowLeft}px` }}
@@ -128,9 +126,9 @@ export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipPro
       </svg>
       <div css={css.body}>
         <Text variant="base" css={css.text}>
-          {t('first_visit_tooltip.body')}
+          {text}
         </Text>
-        <button css={css.closeBtn} onClick={onDismiss} aria-label={t('first_visit_tooltip.dismiss')}>
+        <button css={css.closeBtn} onClick={onDismiss} aria-label={dismissAriaLabel}>
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
           </svg>

--- a/src/components/widgets/first-visit-tooltip.tsx
+++ b/src/components/widgets/first-visit-tooltip.tsx
@@ -1,46 +1,88 @@
+import type { RefObject } from 'react'
+import { useEffect, useState } from 'react'
 import { Text } from '@/components/text'
-import { CloseIcon } from '@/lib/asset'
 import { useTranslation } from '@/lib/locale'
 import { useCss } from '@/lib/theme'
 
 interface FirstVisitTooltipProps {
   onDismiss: () => void
+  anchorRef: RefObject<HTMLElement | null>
 }
+
+const TOOLTIP_WIDTH = 240
+const VIEWPORT_PADDING = 12
+const ARROW_WIDTH = 32
+const ARROW_HEIGHT = 16
+const ARROW_GAP = 14
 
 // Tooltip anchored beneath the fitting-room icon, shown once per browser
 // (first time the icon mounts; dismissed by click on icon, close button, or
 // click outside — see fitting-room-icon.tsx for the dismiss wiring).
-export function FirstVisitTooltip({ onDismiss }: FirstVisitTooltipProps) {
+//
+// Positioned with `position: fixed` against the icon's screen rect so we can
+// horizontally centre the tooltip under the icon, then clamp to keep both
+// edges inside the viewport with a small padding. The arrow then re-anchors
+// to the icon's centre regardless of where the tooltip ended up.
+export function FirstVisitTooltip({ onDismiss, anchorRef }: FirstVisitTooltipProps) {
   const { t } = useTranslation()
+  const [pos, setPos] = useState<{ left: number; top: number; arrowLeft: number } | null>(null)
+
+  useEffect(() => {
+    const compute = () => {
+      const anchor = anchorRef.current
+      if (!anchor) {
+        return
+      }
+      const rect = anchor.getBoundingClientRect()
+      const iconCentre = rect.left + rect.width / 2
+      let left = iconCentre - TOOLTIP_WIDTH / 2
+      const maxLeft = window.innerWidth - TOOLTIP_WIDTH - VIEWPORT_PADDING
+      if (left > maxLeft) {
+        left = maxLeft
+      }
+      if (left < VIEWPORT_PADDING) {
+        left = VIEWPORT_PADDING
+      }
+      const top = rect.bottom + ARROW_GAP
+      // Arrow centres on the icon — independent of where the tooltip
+      // body ended up after clamping.
+      const arrowLeftRaw = iconCentre - left - ARROW_WIDTH / 2
+      const arrowLeftClamped = Math.max(8, Math.min(TOOLTIP_WIDTH - ARROW_WIDTH - 8, arrowLeftRaw))
+      setPos({ left, top, arrowLeft: arrowLeftClamped })
+    }
+    compute()
+    window.addEventListener('resize', compute)
+    window.addEventListener('scroll', compute, true)
+    return () => {
+      window.removeEventListener('resize', compute)
+      window.removeEventListener('scroll', compute, true)
+    }
+  }, [anchorRef])
+
   const css = useCss((theme) => ({
     wrapper: {
-      position: 'absolute',
-      top: '100%',
-      right: 0,
-      marginTop: '12px',
-      width: '240px',
+      position: 'fixed',
+      width: `${TOOLTIP_WIDTH}px`,
       zIndex: 2147483645,
       fontFamily: theme.font_family,
     },
     arrow: {
       position: 'absolute',
-      top: '-7px',
-      right: '14px',
-      width: 0,
-      height: 0,
-      borderLeft: '8px solid transparent',
-      borderRight: '8px solid transparent',
-      borderBottom: `8px solid ${theme.color_fg_text}`,
+      top: `-${ARROW_HEIGHT - 1}px`,
+      width: `${ARROW_WIDTH}px`,
+      height: `${ARROW_HEIGHT}px`,
+      color: theme.color_tfr_800,
+      pointerEvents: 'none',
     },
     body: {
-      backgroundColor: theme.color_fg_text,
+      backgroundColor: theme.color_tfr_800,
       color: '#FFFFFF',
       padding: '12px 14px',
       borderRadius: '8px',
       boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
       display: 'flex',
       alignItems: 'flex-start',
-      gap: '8px',
+      gap: '4px',
     },
     text: {
       flex: 1,
@@ -54,7 +96,7 @@ export function FirstVisitTooltip({ onDismiss }: FirstVisitTooltipProps) {
       borderRadius: '10px',
       border: 'none',
       backgroundColor: 'transparent',
-      color: '#FFFFFF',
+      color: '#F0F0F0',
       cursor: 'pointer',
       padding: 0,
       display: 'flex',
@@ -62,22 +104,36 @@ export function FirstVisitTooltip({ onDismiss }: FirstVisitTooltipProps) {
       justifyContent: 'center',
       flex: 'none',
     },
-    closeIcon: {
-      width: '10px',
-      height: '10px',
-      color: '#FFFFFF',
-    },
   }))
 
+  if (!pos) {
+    return null
+  }
+
   return (
-    <div css={css.wrapper} role="dialog" aria-label={t('first_visit_tooltip.body')}>
-      <div css={css.arrow} />
+    <div
+      css={css.wrapper}
+      style={{ left: `${pos.left}px`, top: `${pos.top}px` }}
+      role="dialog"
+      aria-label={t('first_visit_tooltip.body')}
+    >
+      <svg
+        css={css.arrow}
+        style={{ left: `${pos.arrowLeft}px` }}
+        viewBox={`0 0 ${ARROW_WIDTH} ${ARROW_HEIGHT}`}
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <polygon points={`0,${ARROW_HEIGHT} ${ARROW_WIDTH / 2},0 ${ARROW_WIDTH},${ARROW_HEIGHT}`} fill="currentColor" />
+      </svg>
       <div css={css.body}>
         <Text variant="base" css={css.text}>
           {t('first_visit_tooltip.body')}
         </Text>
         <button css={css.closeBtn} onClick={onDismiss} aria-label={t('first_visit_tooltip.dismiss')}>
-          <CloseIcon css={css.closeIcon} />
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+          </svg>
         </button>
       </div>
     </div>

--- a/src/components/widgets/first-visit-tooltip.tsx
+++ b/src/components/widgets/first-visit-tooltip.tsx
@@ -1,0 +1,85 @@
+import { Text } from '@/components/text'
+import { CloseIcon } from '@/lib/asset'
+import { useTranslation } from '@/lib/locale'
+import { useCss } from '@/lib/theme'
+
+interface FirstVisitTooltipProps {
+  onDismiss: () => void
+}
+
+// Tooltip anchored beneath the fitting-room icon, shown once per browser
+// (first time the icon mounts; dismissed by click on icon, close button, or
+// click outside — see fitting-room-icon.tsx for the dismiss wiring).
+export function FirstVisitTooltip({ onDismiss }: FirstVisitTooltipProps) {
+  const { t } = useTranslation()
+  const css = useCss((theme) => ({
+    wrapper: {
+      position: 'absolute',
+      top: '100%',
+      right: 0,
+      marginTop: '12px',
+      width: '240px',
+      zIndex: 2147483645,
+      fontFamily: theme.font_family,
+    },
+    arrow: {
+      position: 'absolute',
+      top: '-7px',
+      right: '14px',
+      width: 0,
+      height: 0,
+      borderLeft: '8px solid transparent',
+      borderRight: '8px solid transparent',
+      borderBottom: `8px solid ${theme.color_fg_text}`,
+    },
+    body: {
+      backgroundColor: theme.color_fg_text,
+      color: '#FFFFFF',
+      padding: '12px 14px',
+      borderRadius: '8px',
+      boxShadow: '0 6px 20px rgba(0, 0, 0, 0.18)',
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: '8px',
+    },
+    text: {
+      flex: 1,
+      fontSize: '13px',
+      lineHeight: '1.4',
+      color: '#FFFFFF',
+    },
+    closeBtn: {
+      width: '20px',
+      height: '20px',
+      borderRadius: '10px',
+      border: 'none',
+      backgroundColor: 'transparent',
+      color: '#FFFFFF',
+      cursor: 'pointer',
+      padding: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: 'none',
+    },
+    closeIcon: {
+      width: '10px',
+      height: '10px',
+      color: '#FFFFFF',
+    },
+  }))
+
+  return (
+    <div css={css.wrapper} role="dialog" aria-label={t('first_visit_tooltip.body')}>
+      <div css={css.arrow} />
+      <div css={css.body}>
+        <Text variant="base" css={css.text}>
+          {t('first_visit_tooltip.body')}
+        </Text>
+        <button css={css.closeBtn} onClick={onDismiss} aria-label={t('first_visit_tooltip.dismiss')}>
+          <CloseIcon css={css.closeIcon} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/fitting-room-icon.tsx
+++ b/src/components/widgets/fitting-room-icon.tsx
@@ -12,7 +12,7 @@ import { FirstVisitTooltip } from './first-visit-tooltip'
 
 const logger = getLogger('widgets/fitting-room-icon')
 
-const DRAWER_AUTO_DISMISS_MS = 4000
+const DRAWER_AUTO_DISMISS_MS = 6000
 const TOOLTIP_AUTO_DISMISS_MS = 10000
 const FIRST_VISIT_KEY = 'tfr:first-visit-tooltip-seen:v1'
 
@@ -37,6 +37,7 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
   const [showTooltip, setShowTooltip] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const drawerAutoDismissTimerRef = useRef<number | null>(null)
 
   // First-visit detection. One-shot per browser via localStorage.
   useEffect(() => {
@@ -69,17 +70,30 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
     return () => window.clearTimeout(timer)
   }, [showTooltip, dismissTooltip])
 
+  const cancelDrawerAutoDismiss = useCallback(() => {
+    if (drawerAutoDismissTimerRef.current !== null) {
+      window.clearTimeout(drawerAutoDismissTimerRef.current)
+      drawerAutoDismissTimerRef.current = null
+    }
+  }, [])
+
   // Fire the drawer on every add (timestamp changes even for re-adds of the
   // same externalId). Start the auto-dismiss timer in the same effect so a
-  // second add resets it.
+  // second add resets it. Once the shopper interacts with the drawer (hover,
+  // pointer, focus) the timer is cancelled — see cancelDrawerAutoDismiss
+  // wired to the drawer below.
   useEffect(() => {
     if (!lastAddEvent) {
       return
     }
     setDrawerOpen(true)
-    const timer = window.setTimeout(() => setDrawerOpen(false), DRAWER_AUTO_DISMISS_MS)
-    return () => window.clearTimeout(timer)
-  }, [lastAddEvent])
+    cancelDrawerAutoDismiss()
+    drawerAutoDismissTimerRef.current = window.setTimeout(() => {
+      setDrawerOpen(false)
+      drawerAutoDismissTimerRef.current = null
+    }, DRAWER_AUTO_DISMISS_MS)
+    return cancelDrawerAutoDismiss
+  }, [lastAddEvent, cancelDrawerAutoDismiss])
 
   // Click-outside dismisses both the drawer and the tooltip. Inside-clicks
   // (icon button itself, drawer rows, trash, CTA, tooltip close) sit inside
@@ -185,7 +199,11 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
         {count > 0 && <span css={css.badge}>{count}</span>}
       </button>
       {drawerOpen ? (
-        <AddConfirmationDrawer onDismiss={() => setDrawerOpen(false)} onOpenOverlay={handleOpenFromDrawer} />
+        <AddConfirmationDrawer
+          onDismiss={() => setDrawerOpen(false)}
+          onOpenOverlay={handleOpenFromDrawer}
+          onInteract={cancelDrawerAutoDismiss}
+        />
       ) : showTooltip ? (
         <FirstVisitTooltip onDismiss={dismissTooltip} anchorRef={buttonRef} />
       ) : null}

--- a/src/components/widgets/fitting-room-icon.tsx
+++ b/src/components/widgets/fitting-room-icon.tsx
@@ -1,5 +1,5 @@
 import { keyframes } from '@emotion/react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FittingRoomIcon } from '@/lib/asset'
 import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
@@ -13,6 +13,7 @@ import { FirstVisitTooltip } from './first-visit-tooltip'
 const logger = getLogger('widgets/fitting-room-icon')
 
 const DRAWER_AUTO_DISMISS_MS = 4000
+const TOOLTIP_AUTO_DISMISS_MS = 10000
 const FIRST_VISIT_KEY = 'tfr:first-visit-tooltip-seen:v1'
 
 // Soft teal box-shadow pulse — only animates while the first-visit tooltip
@@ -48,14 +49,25 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
     }
   }, [])
 
-  const dismissTooltip = () => {
+  const dismissTooltip = useCallback(() => {
     setShowTooltip(false)
     try {
       window.localStorage.setItem(FIRST_VISIT_KEY, 'true')
     } catch (error) {
       logger.logWarn('Failed to write first-visit flag', { error })
     }
-  }
+  }, [])
+
+  // Auto-dismiss the tooltip after 10s — the shopper has had time to see it;
+  // we still write the localStorage flag so it doesn't re-appear on the next
+  // page load.
+  useEffect(() => {
+    if (!showTooltip) {
+      return
+    }
+    const timer = window.setTimeout(dismissTooltip, TOOLTIP_AUTO_DISMISS_MS)
+    return () => window.clearTimeout(timer)
+  }, [showTooltip, dismissTooltip])
 
   // Fire the drawer on every add (timestamp changes even for re-adds of the
   // same externalId). Start the auto-dismiss timer in the same effect so a
@@ -88,7 +100,7 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
     }
     document.addEventListener('mousedown', onDocClick)
     return () => document.removeEventListener('mousedown', onDocClick)
-  }, [drawerOpen, showTooltip])
+  }, [drawerOpen, showTooltip, dismissTooltip])
 
   // When the user removes the last item from inside the drawer, dismiss it.
   useEffect(() => {

--- a/src/components/widgets/fitting-room-icon.tsx
+++ b/src/components/widgets/fitting-room-icon.tsx
@@ -15,13 +15,13 @@ const logger = getLogger('widgets/fitting-room-icon')
 const DRAWER_AUTO_DISMISS_MS = 4000
 const FIRST_VISIT_KEY = 'tfr:first-visit-tooltip-seen:v1'
 
-// Soft green box-shadow pulse — only animates while the first-visit tooltip
-// is showing. Reuses the #22C55E green from the card-select badge / checkbox
-// (the only attention colour in the SDK today).
+// Soft teal box-shadow pulse — only animates while the first-visit tooltip
+// is showing. Reuses the #265A64 TFR teal (theme.color_tfr_800), the same
+// colour the card-select toggle and selected-card border use.
 const pulse = keyframes`
-  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.6); }
-  70%  { box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+  0%   { box-shadow: 0 0 0 0 rgba(38, 90, 100, 0.6); }
+  70%  { box-shadow: 0 0 0 10px rgba(38, 90, 100, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(38, 90, 100, 0); }
 `
 
 export default function FittingRoomIconWidget(_props: WidgetProps) {
@@ -35,6 +35,7 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
   // First-visit detection. One-shot per browser via localStorage.
   useEffect(() => {
@@ -162,6 +163,7 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
   return (
     <div ref={wrapperRef} css={css.wrapper}>
       <button
+        ref={buttonRef}
         type="button"
         onClick={handleClick}
         css={{ ...css.button, ...(showTooltip && !drawerOpen ? css.buttonPulsing : {}) }}
@@ -173,7 +175,7 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
       {drawerOpen ? (
         <AddConfirmationDrawer onDismiss={() => setDrawerOpen(false)} onOpenOverlay={handleOpenFromDrawer} />
       ) : showTooltip ? (
-        <FirstVisitTooltip onDismiss={dismissTooltip} />
+        <FirstVisitTooltip onDismiss={dismissTooltip} anchorRef={buttonRef} />
       ) : null}
     </div>
   )

--- a/src/components/widgets/fitting-room-icon.tsx
+++ b/src/components/widgets/fitting-room-icon.tsx
@@ -205,7 +205,12 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
           onInteract={cancelDrawerAutoDismiss}
         />
       ) : showTooltip ? (
-        <FirstVisitTooltip onDismiss={dismissTooltip} anchorRef={buttonRef} />
+        <FirstVisitTooltip
+          text={t('first_visit_tooltip.body')}
+          dismissAriaLabel={t('first_visit_tooltip.dismiss')}
+          onDismiss={dismissTooltip}
+          anchorRef={buttonRef}
+        />
       ) : null}
     </div>
   )

--- a/src/components/widgets/fitting-room-icon.tsx
+++ b/src/components/widgets/fitting-room-icon.tsx
@@ -1,3 +1,5 @@
+import { keyframes } from '@emotion/react'
+import { useEffect, useRef, useState } from 'react'
 import { FittingRoomIcon } from '@/lib/asset'
 import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
@@ -5,8 +7,22 @@ import { useMainStore } from '@/lib/store'
 import { useCss } from '@/lib/theme'
 import type { WidgetProps } from '@/lib/view'
 import { OverlayName } from '@/lib/view'
+import { AddConfirmationDrawer } from './add-confirmation-drawer'
+import { FirstVisitTooltip } from './first-visit-tooltip'
 
 const logger = getLogger('widgets/fitting-room-icon')
+
+const DRAWER_AUTO_DISMISS_MS = 4000
+const FIRST_VISIT_KEY = 'tfr:first-visit-tooltip-seen:v1'
+
+// Soft green box-shadow pulse — only animates while the first-visit tooltip
+// is showing. Reuses the #22C55E green from the card-select badge / checkbox
+// (the only attention colour in the SDK today).
+const pulse = keyframes`
+  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.6); }
+  70%  { box-shadow: 0 0 0 10px rgba(34, 197, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+`
 
 export default function FittingRoomIconWidget(_props: WidgetProps) {
   const { t } = useTranslation()
@@ -14,8 +30,77 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
   const isOpen = useMainStore((state) => state.activeOverlay === OverlayName.FITTING_ROOM)
   const openOverlay = useMainStore((state) => state.openOverlay)
   const closeOverlay = useMainStore((state) => state.closeOverlay)
+  const lastAddEvent = useMainStore((state) => state.lastAddEvent)
+
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [showTooltip, setShowTooltip] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  // First-visit detection. One-shot per browser via localStorage.
+  useEffect(() => {
+    try {
+      if (!window.localStorage.getItem(FIRST_VISIT_KEY)) {
+        setShowTooltip(true)
+      }
+    } catch (error) {
+      logger.logWarn('Failed to read first-visit flag', { error })
+    }
+  }, [])
+
+  const dismissTooltip = () => {
+    setShowTooltip(false)
+    try {
+      window.localStorage.setItem(FIRST_VISIT_KEY, 'true')
+    } catch (error) {
+      logger.logWarn('Failed to write first-visit flag', { error })
+    }
+  }
+
+  // Fire the drawer on every add (timestamp changes even for re-adds of the
+  // same externalId). Start the auto-dismiss timer in the same effect so a
+  // second add resets it.
+  useEffect(() => {
+    if (!lastAddEvent) {
+      return
+    }
+    setDrawerOpen(true)
+    const timer = window.setTimeout(() => setDrawerOpen(false), DRAWER_AUTO_DISMISS_MS)
+    return () => window.clearTimeout(timer)
+  }, [lastAddEvent])
+
+  // Click-outside dismisses both the drawer and the tooltip. Inside-clicks
+  // (icon button itself, drawer rows, trash, CTA, tooltip close) sit inside
+  // wrapperRef.
+  useEffect(() => {
+    if (!drawerOpen && !showTooltip) {
+      return
+    }
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        if (drawerOpen) {
+          setDrawerOpen(false)
+        }
+        if (showTooltip) {
+          dismissTooltip()
+        }
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [drawerOpen, showTooltip])
+
+  // When the user removes the last item from inside the drawer, dismiss it.
+  useEffect(() => {
+    if (drawerOpen && count === 0) {
+      setDrawerOpen(false)
+    }
+  }, [drawerOpen, count])
 
   const css = useCss((theme) => ({
+    wrapper: {
+      position: 'relative',
+      display: 'inline-block',
+    },
     button: {
       position: 'relative',
       display: 'inline-flex',
@@ -28,6 +113,10 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
       border: 'none',
       cursor: 'pointer',
       color: 'inherit',
+    },
+    buttonPulsing: {
+      borderRadius: '50%',
+      animation: `${pulse} 1.8s ease-out infinite`,
     },
     icon: {
       width: '24px',
@@ -52,6 +141,9 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
   }))
 
   const handleClick = () => {
+    if (showTooltip) {
+      dismissTooltip()
+    }
     if (isOpen) {
       logger.logDebug('{{ts}} - Closing fitting room overlay', { count })
       closeOverlay()
@@ -59,12 +151,30 @@ export default function FittingRoomIconWidget(_props: WidgetProps) {
     }
     logger.logDebug('{{ts}} - Opening fitting room overlay', { count })
     openOverlay(OverlayName.FITTING_ROOM)
+    setDrawerOpen(false)
+  }
+
+  const handleOpenFromDrawer = () => {
+    openOverlay(OverlayName.FITTING_ROOM)
+    setDrawerOpen(false)
   }
 
   return (
-    <button type="button" onClick={handleClick} css={css.button} aria-label={t('view_fitting_room')}>
-      <FittingRoomIcon css={css.icon} />
-      {count > 0 && <span css={css.badge}>{count}</span>}
-    </button>
+    <div ref={wrapperRef} css={css.wrapper}>
+      <button
+        type="button"
+        onClick={handleClick}
+        css={{ ...css.button, ...(showTooltip && !drawerOpen ? css.buttonPulsing : {}) }}
+        aria-label={t('view_fitting_room')}
+      >
+        <FittingRoomIcon css={css.icon} />
+        {count > 0 && <span css={css.badge}>{count}</span>}
+      </button>
+      {drawerOpen ? (
+        <AddConfirmationDrawer onDismiss={() => setDrawerOpen(false)} onOpenOverlay={handleOpenFromDrawer} />
+      ) : showTooltip ? (
+        <FirstVisitTooltip onDismiss={dismissTooltip} />
+      ) : null}
+    </div>
   )
 }

--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -12,6 +12,7 @@ import LoadingCircleIcon from '@/assets/loading-circle.svg?react'
 import SelectedItemsIcon from '@/assets/icon-selected-items.svg?react'
 import TfrIcon from '@/assets/tfr-icon.svg?react'
 import TfrNameSvg from '@/assets/tfr-name.svg?react'
+import TrashIcon from '@/assets/trash-icon.svg?react'
 import TuckIcon from '@/assets/icon-tuck.svg?react'
 import ZoomIcon from '@/assets/icon-zoom.svg?react'
 import { getStaticData } from '@/lib/store'
@@ -31,6 +32,7 @@ export {
   SelectedItemsIcon,
   TfrIcon,
   TfrNameSvg,
+  TrashIcon,
   TuckIcon,
   ZoomIcon,
 }

--- a/src/lib/fitting-room-data.ts
+++ b/src/lib/fitting-room-data.ts
@@ -60,7 +60,16 @@ export async function loadFittingRoomData(): Promise<void> {
     loadProductDataToStore(item.externalId)
   }
 
-  // Fan out merchant lookups in a single batch for items missing merchant data.
+  await loadMerchantProductData(items)
+}
+
+// Fan out merchant (Shopify, etc) productLookup in a single batch for items
+// missing data. Idempotent: existing store entries are not re-fetched.
+// Extracted from loadFittingRoomData so widgets that surface merchant info
+// outside the overlay (e.g. the add-confirmation drawer) can trigger the
+// same lookup without pulling in the TFR product/style-category loads.
+export async function loadMerchantProductData(items: FittingRoomItem[]): Promise<void> {
+  const state = useMainStore.getState()
   const { productLookup } = getStaticData()
   if (!productLookup) {
     for (const item of items) {

--- a/src/lib/fitting-room-storage.ts
+++ b/src/lib/fitting-room-storage.ts
@@ -144,6 +144,7 @@ async function addFittingRoomItem(productId: string, handle: string | null, isPd
     colorwaySizeAssetId: null,
     addedAt: Date.now(),
   })
+  state.setLastAddEvent(productId)
 }
 
 // Re-read currentProduct's selected color and, if the product is already in

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -103,6 +103,15 @@ export interface MainStoreState {
   updateFittingRoomItem: (externalId: string, patch: Partial<FittingRoomItem>) => void
   clearFittingRoom: () => void
 
+  // Transient cross-widget signal: the most recent add to the fitting room.
+  // `at` is the wall-clock ms of the add — re-adding the same externalId
+  // changes `at`, so subscribers can re-fire on every add (not just changes
+  // of externalId). Set by addFittingRoomItem in fitting-room-storage.ts;
+  // watched by the fitting-room-icon widget to show the confirmation drawer.
+  // Not persisted to localStorage.
+  lastAddEvent: { externalId: string; at: number } | null
+  setLastAddEvent: (externalId: string) => void
+
   // UI state:
   activeOverlay: OverlayName | null
   activeOverlayProps: Record<string, unknown> | null
@@ -190,6 +199,9 @@ export const useMainStore = create<MainStoreState>((set) => ({
       writeFittingRoom(getStaticData().brandId, [])
       return { fittingRoom: [] }
     }),
+
+  lastAddEvent: null,
+  setLastAddEvent: (externalId: string) => set({ lastAddEvent: { externalId, at: Date.now() } }),
 
   // UI state:
   activeOverlay: null,

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -9,6 +9,10 @@
     "body": "See your fitting room here",
     "dismiss": "Dismiss"
   },
+  "first_add_tooltip": {
+    "body": "Add to your fitting room here",
+    "dismiss": "Dismiss"
+  },
   "add_confirmation": {
     "title": "Your Fitting Room",
     "added_header": "Added to your fitting room",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -5,6 +5,17 @@
   "add_to_fitting_room": "Add to Fitting Room",
   "added_to_fitting_room": "In Fitting Room",
   "view_fitting_room": "Fitting Room",
+  "first_visit_tooltip": {
+    "body": "See your fitting room here",
+    "dismiss": "Dismiss"
+  },
+  "add_confirmation": {
+    "title": "Your Fitting Room",
+    "added_header": "Added to your fitting room",
+    "cta": "Go to your fitting room",
+    "remove": "Remove from fitting room",
+    "dismiss": "Dismiss"
+  },
   "fitting_room": {
     "title": "Fitting Room",
     "empty": "Your fitting room is empty.",
@@ -25,6 +36,7 @@
     "avatar_placeholder_selected": "Avatar render will appear here once VTO is wired up.",
     "see_selected_items": "See Selected Items",
     "no_selection": "Nothing selected yet.",
+    "toggle_selection": "Toggle try-on selection",
     "tuck_in": "Tuck In",
     "untuck": "Untuck",
     "zoom_in": "Zoom In",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -6,11 +6,11 @@
   "added_to_fitting_room": "In Fitting Room",
   "view_fitting_room": "Fitting Room",
   "first_visit_tooltip": {
-    "body": "See your fitting room here",
+    "body": "See items added to your fitting room here",
     "dismiss": "Dismiss"
   },
   "first_add_tooltip": {
-    "body": "Add to your fitting room here",
+    "body": "Add item to your fitting room here",
     "dismiss": "Dismiss"
   },
   "add_confirmation": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -5,6 +5,17 @@
   "add_to_fitting_room": "Ajouter à la cabine d'essayage",
   "added_to_fitting_room": "Dans la cabine d'essayage",
   "view_fitting_room": "Cabine d'essayage",
+  "first_visit_tooltip": {
+    "body": "Voici votre cabine d'essayage",
+    "dismiss": "Fermer"
+  },
+  "add_confirmation": {
+    "title": "Votre cabine d'essayage",
+    "added_header": "Ajouté à votre cabine d'essayage",
+    "cta": "Aller à votre cabine d'essayage",
+    "remove": "Retirer de la cabine d'essayage",
+    "dismiss": "Fermer"
+  },
   "fitting_room": {
     "title": "Cabine d'essayage",
     "empty": "Votre cabine d'essayage est vide.",
@@ -24,6 +35,7 @@
     "avatar_placeholder_selected": "L'avatar apparaîtra ici lorsque la VTO sera connectée.",
     "see_selected_items": "Voir la sélection",
     "no_selection": "Rien de sélectionné.",
+    "toggle_selection": "Activer/désactiver la sélection",
     "tuck_in": "Rentrer",
     "untuck": "Sortir",
     "zoom_in": "Zoom +",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -6,11 +6,11 @@
   "added_to_fitting_room": "Dans la cabine d'essayage",
   "view_fitting_room": "Cabine d'essayage",
   "first_visit_tooltip": {
-    "body": "Voici votre cabine d'essayage",
+    "body": "Voir les articles ajoutés à votre cabine d'essayage ici",
     "dismiss": "Fermer"
   },
   "first_add_tooltip": {
-    "body": "Ajoutez à votre cabine d'essayage ici",
+    "body": "Ajoutez un article à votre cabine d'essayage ici",
     "dismiss": "Fermer"
   },
   "add_confirmation": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -9,6 +9,10 @@
     "body": "Voici votre cabine d'essayage",
     "dismiss": "Fermer"
   },
+  "first_add_tooltip": {
+    "body": "Ajoutez à votre cabine d'essayage ici",
+    "dismiss": "Fermer"
+  },
   "add_confirmation": {
     "title": "Votre cabine d'essayage",
     "added_header": "Ajouté à votre cabine d'essayage",


### PR DESCRIPTION
## Summary
- **Toggle-pill control on every rail card** (replaces the conditional selected badge): three states — selected (teal track, thumb right), unselected (grey track, thumb left), disabled (greyed, non-interactive). Card body still toggles selection; toggle is an explicit affordance and redundant click target.
- **Trash icon for remove** on both rail cards and the desktop avatar-controls popover (was an "X"). Makes "ejects from fitting room entirely" obvious.
- **First-view tooltip on the header fitting-room icon**: white body, teal border, centred text, fat 32×16 teal SVG arrow, soft teal pulse on the icon while showing. Anchored with `position: fixed` against the icon's screen rect and clamped to the viewport. Dismisses on icon click, close X, click-outside, or after 10s. One-shot per browser via `tfr:first-visit-tooltip-seen:v1`.
- **Second first-view tooltip on the add-to-fitting-room hanger** ("Add item to your fitting room here"): same visual treatment, same pulse. Module-level claim flag so only the first hanger on a catalog page surfaces it (rather than racing across N cards). One-shot per browser via `tfr:first-add-tooltip-seen:v1`.
- **Add-confirmation mini-drawer** anchored beneath the header icon, firing on every add (via new `lastAddEvent` store signal funneled through `addFittingRoomItem`). Title centred, items with image / name / "colour · price" / trash, "Go to your fitting room" CTA. 6s auto-dismiss; cancels on first drawer interaction (hover/pointer/focus) so engaged shoppers don't have it close out from under them.
- **`loadMerchantProductData` extracted** from `loadFittingRoomData` so the drawer can populate items on mount (it fires before the overlay opens, so the cache would otherwise be empty for fresh-from-catalog adds).
- **Card visual refresh**: 1.5px light-grey border with 8px rounded corners on every card, TFR teal border on selected; more internal padding (12px / 20px); wider gap between cards (16px).

## Test plan
- [ ] `npm run check` + `npm run test:e2e` (6/6) + `npm run build` green
- [ ] Cold smoke (clear localStorage, `?tfr-source=local-demo`):
  - [ ] First visit to any page: header icon pulses, tooltip "See items added to your fitting room here" beneath. Dismisses on icon click / close X / click outside / 10s. Doesn't reappear on reload.
  - [ ] First catalog page after that: first hanger pulses, "Add item to your fitting room here" tooltip beneath. Same dismiss paths. Doesn't reappear.
  - [ ] Add an item (catalog hanger, PDP, or quick-view): mini-drawer pops beneath header icon with proper image + name + price. Auto-dismiss after 6s. Hover/click inside cancels auto-dismiss.
  - [ ] Remove inside drawer: item drops from list; removing the last item dismisses drawer.
  - [ ] CTA opens the fitting-room overlay and closes drawer.
- [ ] Inside overlay:
  - [ ] Every card has a teal/grey toggle pill top-left. Tapping toggles selection; tapping the card body also toggles.
  - [ ] Disabled cards show greyed toggle, non-interactive.
  - [ ] Card border is light grey by default, TFR teal when selected.
  - [ ] Remove glyph is a trash can (both rail card and desktop "See Selected Items" popover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)