### PR TITLE
Suits & Sets: container VTO expansion, outfit cap, tuck toggle

### DIFF
--- a/src/api/gen/enums.ts
+++ b/src/api/gen/enums.ts
@@ -315,6 +315,10 @@ export const StyleCategoryShells: StyleCategory = "shells";
  * Jackets and Coats.
  */
 export const StyleCategoryCloaks: StyleCategory = "cloaks";
+/**
+ * Sets.
+ */
+export const StyleCategorySuitsAndSets: StyleCategory = "suits_and_sets";
 
 //////////
 // source: upload_limits.go

--- a/src/api/gen/requests.ts
+++ b/src/api/gen/requests.ts
@@ -137,6 +137,101 @@ export interface Invitation {
 }
 
 //////////
+// source: set_size_mapping.go
+
+/**
+ * PutSetSizeMappings is the request body for PUT
+ * /v1/styles/:parent_id/set-size-mappings. Merchant sends the complete
+ * desired mapping set for the container-parent style; backend replaces
+ * the existing rows atomically.
+ */
+export interface PutSetSizeMappings {
+  mappings: SetSizeMapping[];
+}
+export interface SetSizeMapping {
+  parent_size_id: number /* int64 */;
+  child_size_id: number /* int64 */;
+}
+/**
+ * SetSizeMappingRef is the reference-based mapping used in the atomic
+ * POST/PUT /v1/styles request bodies where parent / child Size rows may
+ * not have DB ids yet (they're being created in the same request).
+ * Resolution at commit time:
+ *   - ParentSizeLabel matches the label of one of the parent's just-
+ *     upserted container-parent Sizes.
+ *   - ChildStyleIndex is the 0-based index into the request's
+ *     Children[] array (matching the child style whose Sizes we're
+ *     targeting).
+ *   - ChildSizeValueID + optional ChildVerticalSizeValueID uniquely
+ *     identify a Size within the child style (child styles are always
+ *     single-garment).
+ */
+export interface SetSizeMappingRef {
+  parent_size_label: string;
+  child_style_index: number /* int */;
+  child_size_value_id: number /* int64 */;
+  child_vertical_size_value_id: number /* int64 */;
+}
+
+//////////
+// source: set_template.go
+
+/**
+ * SetTemplate is the request body for POST /v1/set-templates and PUT
+ * /v1/set-templates/:id. The template is a reusable preset for
+ * container Suits & Sets styles: N component slots (categories + size
+ * systems) + M set-size labels + a mapping table pairing each set-size
+ * with a per-slot child size value.
+ * SlotIndex and SetSizeIndex are the join keys between the three
+ * child tables; callers pick their own indexes and the handler
+ * validates that Mappings reference existing (slot_index, set_size_index)
+ * pairs and that each pair is covered exactly once per slot.
+ */
+export interface SetTemplate {
+  name: string;
+  slots: SetTemplateSlot[];
+  sizes: SetTemplateSize[];
+  mappings: SetTemplateSizeMapping[];
+}
+/**
+ * SetTemplateSlot describes one component slot in a template. On apply,
+ * each slot spawns a child style with StyleCategoryName copied over.
+ * SlotIndex is the merchant-provided ordering / join key.
+ */
+export interface SetTemplateSlot {
+  slot_index: number /* int */;
+  /**
+   * Name is the merchant-facing per-slot label. Optional; when
+   * omitted the dashboard falls back to the category label on
+   * apply.
+   */
+  name: string;
+  style_category_name: any /* enums.StyleCategory */;
+  size_system_id: number /* int64 */;
+  vertical_size_system_id: number /* int64 */;
+}
+/**
+ * SetTemplateSize is one merchant-defined set-size label + ordering.
+ * On apply, parent Style Sizes are created with label copied and
+ * sort_order = SetSizeIndex.
+ */
+export interface SetTemplateSize {
+  set_size_index: number /* int */;
+  label: string;
+}
+/**
+ * SetTemplateSizeMapping is one row of the (set_size × slot) mapping
+ * grid. For each combination the merchant picks which size_value (and
+ * optional vertical size_value) the child at that slot should carry.
+ */
+export interface SetTemplateSizeMapping {
+  set_size_index: number /* int */;
+  slot_index: number /* int */;
+  slot_size_value_id: number /* int64 */;
+  slot_vertical_size_value_id: number /* int64 */;
+}
+
+//////////
 // source: shopify_store.go
 
 export interface ShopifyStore {
@@ -160,11 +255,38 @@ export interface ColorwayNameSizeAssetSKU {
   colorway_size_asset_sku: string;
 }
 export interface Size {
+  /**
+   * ReferenceSizeValueID FKs to size_values.id — populated on Sizes
+   * whose parent Style is single-garment. Must be zero for
+   * container-parent Sizes (they use ContainerReferenceSizeID /
+   * ContainerReferenceSizeLabel instead). Bindings are permissive
+   * because a single request shape now feeds both single-garment
+   * (PUT /v1/styles/:id/sizes) and container-parent (atomic PUT
+   * /v1/styles/:id) writes; the handler enforces per-style rules.
+   */
   reference_size_value_id: number /* int64 */;
+  /**
+   * ContainerReferenceSizeID FKs to another sizes.id in the same
+   * container-parent style. Used only for container-parent Sizes;
+   * must be zero on single-garment. When both this and
+   * ContainerReferenceSizeLabel are set, the label wins (allowing the
+   * dashboard to point at another Size in the same PUT that hasn't
+   * been persisted yet).
+   */
+  container_reference_size_id: number /* int64 */;
+  /**
+   * ContainerReferenceSizeLabel resolves to another Size's DB id at
+   * PUT time by matching label within the same container-parent
+   * style. Lets a client point at a sibling Size that's being created
+   * in the same atomic PUT (no chicken-and-egg on ids). Ignored for
+   * non-container styles.
+   */
+  container_reference_size_label: string;
   size_value_id: number /* int64 */;
   vertical_size_value_id: number /* int64 */;
   base_body_id: number /* int64 */;
   label: string;
+  sort_order: number /* int */;
   garment_measurements: GarmentMeasurement[];
   colorway_name_size_asset_sku: ColorwayNameSizeAssetSKU[];
 }
@@ -217,6 +339,13 @@ export interface GarmentMeasurement {
   lay_flat: boolean;
 }
 export interface Style {
+  /**
+   * SKU / ExternalID / SizeSystemID are required for single-garment
+   * styles but must be empty on the parent of a Suits & Sets container
+   * (children have no independent merchant identity; parent has no size
+   * system of its own). Validation branches on IsContainer in the
+   * handler — the binding tags stay omitempty so both shapes parse.
+   */
   sku: string;
   external_id: string;
   cycle_id: number /* int64 */;
@@ -228,11 +357,63 @@ export interface Style {
   measurement_unit?: string;
   size_system_id: number /* int64 */;
   vertical_size_system_id: number /* int64 */;
-  placement_measurement_location: string;
-  placement_offset_y: number /* float64 */;
   is_vto: boolean;
+  /**
+   * SetTemplateID is a provenance pointer for container-parent styles
+   * created from a template. Ignored for non-container styles.
+   */
+  set_template_id: number /* int64 */;
+  /**
+   * Children are the container's component child styles. Non-empty
+   * only when the parent's StyleCategoryName is a container category.
+   * Each child inherits BrandID / Description / SaleType / IsVTO /
+   * MeasurementUnit / PublishedAt / CycleID from the parent and
+   * carries its own StyleCategoryName / Sleeves / SizeSystemID /
+   * VerticalSizeSystemID. Max 4 per parent (Q7).
+   */
+  children: StyleChild[];
+  /**
+   * Sizes optionally carries this style's Size rows for atomic
+   * creation. For container-parent styles these are label-only
+   * Set-size rows (validated per writeStyleSizes' container branch);
+   * for single-garment styles they follow the standard shape.
+   */
+  sizes: Size[];
+  /**
+   * SetSizeMappings connects parent Size rows to child Size rows for
+   * a container-parent style. Non-empty only when Children is
+   * non-empty. Coverage rule (every parent_size × child_style pair
+   * mapped exactly once) is validated by writeSetSizeMappings.
+   */
+  set_size_mappings: SetSizeMappingRef[];
+}
+/**
+ * StyleChild is the request shape for one component of a container Set.
+ * Fewer fields than the top-level Style request — inherited fields come
+ * from the parent, and children have no SKU / ExternalID / CycleID of
+ * their own.
+ */
+export interface StyleChild {
+  name: string;
+  style_category_name: any /* enums.StyleCategory */;
+  sleeves?: any /* enums.SleeveLength */;
+  size_system_id: number /* int64 */;
+  vertical_size_system_id: number /* int64 */;
+  component_index: number /* int */;
+  /**
+   * Sizes carries this child's Size rows for atomic creation with
+   * the parent. Single-garment shape (size_value_id + optional
+   * vertical_size_value_id + reference_size_value_id + garment
+   * measurements).
+   */
+  sizes: Size[];
 }
 export interface PutStyle {
+  /**
+   * SKU / ExternalID / SizeSystemID mirror the POST /v1/styles rules:
+   * required for single-garment styles, must be empty for a container
+   * parent. Validation branches on the resolved StyleCategoryName.
+   */
   sku: string;
   external_id: string;
   name: string;
@@ -243,9 +424,44 @@ export interface PutStyle {
   measurement_unit: string;
   size_system_id: number /* int64 */;
   vertical_size_system_id: number /* int64 */;
-  placement_measurement_location: string;
-  placement_offset_y: number /* float64 */;
   is_vto: boolean;
+  set_template_id: number /* int64 */;
+  /**
+   * Children carries the desired complete list of child styles for a
+   * container. Each entry with a non-zero ID updates an existing
+   * child; entries with ID=0 create a new child. Any existing child
+   * NOT present in the list (by ID) is deleted. Max 4 (Q7).
+   */
+  children: PutStyleChild[];
+  /**
+   * Sizes replaces this style's Size rows atomically. See Style.Sizes
+   * for shape rules — container-parent (label-only) vs single-garment.
+   */
+  sizes: Size[];
+  /**
+   * SetSizeMappings replaces the set_size_mappings for a
+   * container-parent style. Same shape/rules as Style.SetSizeMappings.
+   */
+  set_size_mappings: SetSizeMappingRef[];
+}
+/**
+ * PutStyleChild is one row in the container edit's Children[]. ID is
+ * zero for new children (they get inserted) and non-zero for existing
+ * children (they get updated).
+ */
+export interface PutStyleChild {
+  id: number /* int64 */;
+  name: string;
+  style_category_name: any /* enums.StyleCategory */;
+  sleeves?: any /* enums.SleeveLength */;
+  size_system_id: number /* int64 */;
+  vertical_size_system_id: number /* int64 */;
+  component_index: number /* int */;
+  /**
+   * Sizes replaces this child's Size rows atomically. Single-garment
+   * shape.
+   */
+  sizes: Size[];
 }
 export interface StylePatch {
   publish: boolean;

--- a/src/api/gen/responses.ts
+++ b/src/api/gen/responses.ts
@@ -276,7 +276,6 @@ export interface MeasurementLocation {
   is_required_base_body_measurement: boolean;
   sort_order: number /* int64 */;
   group?: MeasurementLocationGroup;
-  is_placement_measurement: boolean;
 }
 
 //////////
@@ -285,6 +284,45 @@ export interface MeasurementLocation {
 export interface MeasurementLocationGroup {
   name: string;
   label: string;
+}
+
+//////////
+// source: set_template.go
+
+/**
+ * SetTemplate is the API response shape for GET / POST / PUT
+ * /v1/set-templates[/:id]. Full snapshot including all three child
+ * tables.
+ */
+export interface SetTemplate {
+  id: number /* int64 */;
+  brand_id: number /* int64 */;
+  name: string;
+  slots: SetTemplateSlot[];
+  sizes: SetTemplateSize[];
+  mappings: SetTemplateSizeMapping[];
+  created_at: any /* time.Time */;
+  updated_at?: any /* time.Time */;
+}
+export interface SetTemplateSlot {
+  id: number /* int64 */;
+  slot_index: number /* int */;
+  name?: string;
+  style_category_name: any /* enums.StyleCategory */;
+  size_system_id: number /* int64 */;
+  vertical_size_system_id?: number /* int64 */;
+}
+export interface SetTemplateSize {
+  id: number /* int64 */;
+  set_size_index: number /* int */;
+  label: string;
+}
+export interface SetTemplateSizeMapping {
+  id: number /* int64 */;
+  set_size_index: number /* int */;
+  slot_index: number /* int */;
+  slot_size_value_id: number /* int64 */;
+  slot_vertical_size_value_id?: number /* int64 */;
 }
 
 //////////
@@ -388,12 +426,25 @@ export interface Size {
   label: string;
   reference_size_value_id: number /* int64 */;
   reference_size_value?: SizeValue;
+  /**
+   * ContainerReferenceSizeID is populated on container-parent Sizes
+   * instead of ReferenceSizeValueID. FKs to another Size row in the
+   * same style. Zero for single-garment Sizes.
+   */
+  container_reference_size_id: number /* int64 */;
   size_value_id: number /* int64 */;
   size_value?: SizeValue;
   vertical_size_value_id: number /* int64 */;
   vertical_size_value?: SizeValue;
   base_body_id: number /* int64 */;
   base_body?: BaseBody;
+  /**
+   * SortOrder is populated for container-parent Sizes (size_value_id NULL).
+   * The size-rec algorithm uses it to find adjacent sizes when
+   * size_value_id-based ordering is unavailable. Zero for regular
+   * single-garment Sizes.
+   */
+  sort_order?: number /* int */;
   garment_measurements: GarmentMeasurement[];
   colorway_size_assets: ColorwaySizeAsset[];
 }
@@ -407,8 +458,10 @@ export interface FirestoreSize {
   garment_measurements?: any[];
   size_value_id: number /* int */;
   reference_size_value_id: number /* int */;
+  container_reference_size_id: number /* int */;
   vertical_size_value_id: number /* int */;
   base_body_id: number /* int */;
+  sort_order?: number /* int */;
   name?: string;
   size_value?: any;
   vertical_size_value?: any;
@@ -641,17 +694,38 @@ export interface Style {
   style_category_label: string;
   sleeves?: any /* enums.SleeveLength */;
   size_system?: SizeSystem;
+  size_system_id: number /* int64 */;
   vertical_size_system?: SizeSystem;
+  vertical_size_system_id: number /* int64 */;
+  component_index?: number /* int */;
+  parent_style_id?: number /* int64 */;
   sizes: Size[];
   colorways: Colorway[];
   colorway_size_assets: ColorwaySizeAsset[];
   measurement_unit: string;
   is_published: boolean;
-  placement_measurement_location: string;
-  placement_offset_y: number /* float64 */;
   is_vto: boolean;
   created_at: any /* time.Time */;
   updated_at?: any /* time.Time */;
+  /**
+   * IsContainer marks this row as a Suits & Sets parent. When true the
+   * dashboard hydrates Components/Sizes/Mappings tabs from Children[]
+   * and SetSizeMappings[]. Non-container styles omit these.
+   */
+  is_container?: boolean;
+  children?: Style[];
+  set_size_mappings?: SetSizeMapping[];
+}
+/**
+ * SetSizeMapping is a single (parent_size_id, child_size_id) row on a
+ * container-parent style. The REST response embeds these on the parent
+ * so the dashboard editor can round-trip mapping state on Edit without
+ * a second fetch.
+ */
+export interface SetSizeMapping {
+  id: number /* int64 */;
+  parent_size_id: number /* int64 */;
+  child_size_id: number /* int64 */;
 }
 export interface FirestoreStyle {
   brand_id: number /* int */;
@@ -673,11 +747,46 @@ export interface FirestoreStyle {
   is_published: boolean;
   created_at: any /* time.Time */;
   updated_at?: any /* time.Time */;
-  placement_measurement_location: string;
-  placement_offset_y: number /* float64 */;
   division_id?: number /* int */;
   colorways?: any[];
   sizes?: any[];
+  /**
+   * IsContainer marks the style as a Suits & Sets parent whose full
+   * composition is described by the Children[] and SetSizeMappings[]
+   * fields below. Non-container styles omit these.
+   */
+  is_container?: boolean;
+  children?: any[];
+  set_size_mappings?: any[];
+}
+/**
+ * FirestoreChildStyle is the shape embedded under FirestoreStyle.Children
+ * for a container-parent style's Firestore snapshot. Child styles do not
+ * get their own top-level document — the SDK reads them off the parent.
+ * Fields inherited from the parent (brand_id, description, etc.) are
+ * omitted since the SDK already has the parent's copy.
+ */
+export interface FirestoreChildStyle {
+  id: number /* int */;
+  name: string;
+  component_index: number /* int */;
+  style_category_name: string;
+  style_category_label: string;
+  sleeves?: string;
+  size_system_id: number /* int */;
+  vertical_size_system_id: number /* int */;
+  colorways?: any[];
+  sizes?: any[];
+}
+/**
+ * FirestoreSetSizeMapping is a single (parent_size_id, child_size_id) row
+ * from set_size_mappings on the parent style's snapshot. The SDK reads
+ * these to expand a shopper-selected parent Size into N per-component
+ * child Sizes.
+ */
+export interface FirestoreSetSizeMapping {
+  parent_size_id: number /* int */;
+  child_size_id: number /* int */;
 }
 
 //////////
@@ -738,6 +847,14 @@ export interface StyleCategory {
    * this one regardless of the group default.
    */
   excludes: any /* enums.StyleCategory */[];
+  /**
+   * IsContainer marks the category as a container (parent-style) type:
+   * Style rows in this category own N child Style rows and are expanded
+   * to N component CSAs at VTO composition time. Dashboard / SDK branch
+   * on this to render container-specific UX. Container categories do
+   * not participate in VTO layering directly (their children do).
+   */
+  is_container: boolean;
 }
 /**
  * StyleCategoryGroup is the API response shape for GET /v1/style-category-groups.

--- a/src/components/overlays/fitting-room/detail-accordion-item.tsx
+++ b/src/components/overlays/fitting-room/detail-accordion-item.tsx
@@ -8,7 +8,7 @@ import { LinkT } from '@/components/link'
 import { SizeSelector } from '@/components/size-selector'
 import { Text, TextT } from '@/components/text'
 import type { ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
-import { buildVtoProductDataFromResolved } from '@/lib/fitting-room-data'
+import { buildVtoProductDataFromResolved, isItemTuckable } from '@/lib/fitting-room-data'
 import { useTranslation } from '@/lib/locale'
 import type { VtoProductData } from '@/lib/product'
 import { useCss } from '@/lib/theme'
@@ -102,8 +102,11 @@ export function DetailAccordionItem({
   const categoryLabel = item.styleCategory?.label_singular ?? item.styleCategory?.label ?? ''
   const productName = item.merchantProduct?.productName ?? item.externalId
   // Mobile tuck CTA shows only when this item is tuckable AND the outfit has
-  // a garment to tuck into (see canTuck in FittingRoomOverlay).
-  const tuckable = !!item.styleCategory?.tuckable && canTuck
+  // a garment to tuck into (see canTuck in FittingRoomOverlay). For
+  // container products (Suits & Sets) the trait is per-child — isItemTuckable
+  // walks effective categories so a Set with a tuckable shirt lights up
+  // the CTA even though the container category itself isn't tuckable.
+  const tuckable = isItemTuckable(item) && canTuck
 
   if (platform === 'desktop') {
     return (

--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -30,11 +30,26 @@ import { useVtoRequests } from '@/lib/use-vto-requests'
 
 // Map our local OutfitItem shape (which carries the externalId for UI bookkeeping)
 // to the wire shape expected by the VTO API.
+//
+// Container products fan out: `childCsaIds` was pre-resolved in
+// makeOutfitItem/buildAlternateOutfits from the shopper's (parent CSA)
+// selection. Each child CSA becomes its own wire item, so an N-piece Set
+// contributes N items[] entries instead of 1. Non-container items keep the
+// 1:1 mapping. `untucked` propagates uniformly to every tuckable child in the
+// container — the PDP will surface a single tuck toggle in Phase C, but even
+// today an ambient outfit-wide `forceUntuck` needs to reach every tuckable
+// component of a Set.
 function toWireItems(items: OutfitItem[]): VtoCompositionItem[] {
-  return items.map((i) => ({
-    colorway_size_asset_id: i.colorwaySizeAssetId,
-    ...(i.untucked ? { untucked: true } : {}),
-  }))
+  return items.flatMap((i) => {
+    const untuckFrag = i.untucked ? { untucked: true } : {}
+    if (i.childCsaIds && i.childCsaIds.length > 0) {
+      return i.childCsaIds.map((csaId) => ({
+        colorway_size_asset_id: csaId,
+        ...untuckFrag,
+      }))
+    }
+    return [{ colorway_size_asset_id: i.colorwaySizeAssetId, ...untuckFrag }]
+  })
 }
 
 const logger = getLogger('overlays/fitting-room')

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -30,7 +30,7 @@ import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
 import type { LoadedProductData, VtoProductData, VtoSizeColorData, VtoSizeData } from '@/lib/product'
 import { buildVtoWireItems, loadProductDataToStore } from '@/lib/product'
-import { loadStyleCategoryIndex } from '@/lib/style-categories'
+import { loadStyleCategoryIndex, peekStyleCategoryIndex } from '@/lib/style-categories'
 import { getStaticData, useMainStore } from '@/lib/store'
 import type { CssProp, StyleProp } from '@/lib/theme'
 import { getThemeData, useCss } from '@/lib/theme'
@@ -77,6 +77,13 @@ export default function QuickViewOverlay() {
   const [selectedSizeLabel, setSelectedSizeLabel] = useState<string | null>(null)
   const [selectedColorLabel, setSelectedColorLabel] = useState<string | null>(null)
   const [modalStyle, setModalStyle] = useState<StyleProp>({})
+  // Container-only tuck toggle (see Suits & Sets plan Q10). Non-container
+  // products never surface a tuck toggle on quick-view — quick-view is
+  // previewing a single product outside an outfit context so there's nothing
+  // for it to tuck into. Containers are different: a Set carries its own
+  // bottoms sibling, so tucking a tuckable shirt over/under has meaning.
+  // State value applies uniformly to every tuckable child at wire-build.
+  const [containerUntucked, setContainerUntucked] = useState(false)
   // Shared VTO request flow: dedup, prefetch throttle, and frame storage.
   // Single-garment compositions are just one-item outfits (untucked: false).
   const { request: vtoRequest, framesForOutfit, lastError: vtoError, clearError: clearVtoError } = useVtoRequests()
@@ -268,6 +275,29 @@ export default function QuickViewOverlay() {
     return entry
   }, [storeProductData])
 
+  // Container tuck toggle gating: only render when this product is a
+  // container AND at least one child garment is tuckable. peekStyleCategoryIndex
+  // returns null before the index resolves (very early frames); the toggle
+  // just stays hidden until the child-category lookup can complete. Recomputes
+  // when the loaded product data changes.
+  const containerHasTuckableChild = useMemo(() => {
+    if (!loadedProduct?.container) {
+      return false
+    }
+    const index = peekStyleCategoryIndex()
+    if (!index) {
+      return false
+    }
+    return loadedProduct.container.children.some((c) => {
+      const cat = index.byName(String(c.style_category_name))
+      return !!cat?.tuckable
+    })
+  }, [loadedProduct])
+
+  const handleToggleContainerUntucked = useCallback(() => {
+    setContainerUntucked((prev) => !prev)
+  }, [])
+
   // Request VTO for a color/size as a one-item outfit. Dedup, the prefetch
   // throttle, and frame storage all live in the shared useVtoRequests hook;
   // single-garment compositions are never untucked. Container products fan
@@ -279,13 +309,18 @@ export default function QuickViewOverlay() {
       if (!loadedProduct) {
         return
       }
-      const wireItems = buildVtoWireItems(loadedProduct, sizeColorRecord.colorwaySizeAssetId, false)
+      // Single-garment products stay hard-coded untucked=false: quick-view
+      // is a preview with no outfit context to tuck INTO. Containers use the
+      // shopper's tuck toggle; buildVtoWireItems propagates the flag to
+      // every emitted child, and non-tuckable children ignore it downstream.
+      const untucked = loadedProduct.container ? containerUntucked : false
+      const wireItems = buildVtoWireItems(loadedProduct, sizeColorRecord.colorwaySizeAssetId, untucked)
       if (!wireItems) {
         return
       }
       vtoRequest(wireItems, priority)
     },
-    [vtoRequest, loadedProduct],
+    [vtoRequest, loadedProduct, containerUntucked],
   )
 
   // Trigger priority VTO request when size/color selection changes
@@ -322,7 +357,8 @@ export default function QuickViewOverlay() {
     if (!selectedColorSizeRecord || !loadedProduct) {
       return null
     }
-    const wireItems = buildVtoWireItems(loadedProduct, selectedColorSizeRecord.colorwaySizeAssetId, false)
+    const untucked = loadedProduct.container ? containerUntucked : false
+    const wireItems = buildVtoWireItems(loadedProduct, selectedColorSizeRecord.colorwaySizeAssetId, untucked)
     if (!wireItems) {
       return null
     }
@@ -336,7 +372,7 @@ export default function QuickViewOverlay() {
       img.src = url
     })
     return rewritten
-  }, [selectedColorSizeRecord, framesForOutfit, loadedProduct])
+  }, [selectedColorSizeRecord, framesForOutfit, loadedProduct, containerUntucked])
 
   const handleSignOutClick = useCallback(() => {
     closeOverlay()
@@ -432,6 +468,9 @@ export default function QuickViewOverlay() {
         onChangeSize={setSelectedSizeLabel}
         onAddToCart={handleAddToCartClick}
         onSignOut={handleSignOutClick}
+        containerTuckable={containerHasTuckableChild}
+        containerUntucked={containerUntucked}
+        onToggleUntuck={handleToggleContainerUntucked}
       />
       {vtoError ? <Snackbar messageKey="quick-view.vto_error" onDismiss={clearVtoError} /> : null}
     </SidecarModalFrame>
@@ -533,6 +572,45 @@ function FittingRoomToggleButton() {
   )
 }
 
+// ContainerTuckToggleButton sits beneath FittingRoomToggleButton on
+// container product PDPs when at least one child garment is tuckable.
+// One toggle uniformly flips every tuckable child's `untucked` bool at
+// wire-build (see buildVtoWireItems). Non-container products never render
+// this button — quick-view has no outfit context for a single garment to
+// tuck into. TODO(container-tuck-mobile): mobile-layout equivalent —
+// the sub-content components (MobileContentCollapsed / Expanded / Full)
+// don't yet receive the tuck props from LayoutProps.
+function ContainerTuckToggleButton({ untucked, onToggle }: { untucked: boolean; onToggle: () => void }) {
+  const css = useCss((theme) => ({
+    button: {
+      marginTop: '10px',
+      width: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '10px',
+      padding: '13px',
+      backgroundColor: '#FFFFFF',
+      border: `1px solid ${theme.color_fg_text}`,
+      borderRadius: '30px',
+      cursor: 'pointer',
+    },
+    text: {
+      fontSize: '14px',
+      textTransform: 'uppercase',
+    },
+  }))
+  return (
+    <button type="button" onClick={onToggle} css={css.button}>
+      <TextT
+        variant="base"
+        css={css.text}
+        t={untucked ? 'fitting_room.try_it_tucked_in' : 'fitting_room.try_it_untucked'}
+      />
+    </button>
+  )
+}
+
 interface LayoutProps {
   loadedProductData: VtoProductData
   selectedColorSizeRecord: VtoSizeColorData
@@ -546,6 +624,14 @@ interface LayoutProps {
   onChangeSize: (newSizeLabel: string) => void
   onAddToCart: () => void
   onSignOut: () => void
+  // Container tuck toggle (see Suits & Sets plan Q10). When
+  // containerTuckable is false the toggle isn't rendered at all — that's
+  // the gate for single-garment products and containers with no tuckable
+  // child. containerUntucked reflects the current state; onToggleUntuck
+  // flips it.
+  containerTuckable: boolean
+  containerUntucked: boolean
+  onToggleUntuck: () => void
 }
 
 type MobileContentView = 'collapsed' | 'expanded' | 'full'
@@ -1029,6 +1115,9 @@ function DesktopLayout({
   onChangeSize,
   onAddToCart,
   onSignOut,
+  containerTuckable,
+  containerUntucked,
+  onToggleUntuck,
 }: LayoutProps) {
   const { t } = useTranslation()
   const [fitChartOpen, setFitChartOpen] = useState<boolean>(false)
@@ -1191,6 +1280,9 @@ function DesktopLayout({
           <div css={css.buttonContainer}>
             <AddToCartButton onClick={onAddToCart} />
             <FittingRoomToggleButton />
+            {containerTuckable ? (
+              <ContainerTuckToggleButton untucked={containerUntucked} onToggle={onToggleUntuck} />
+            ) : null}
           </div>
           <div css={css.descriptionContainer}>
             <ProductDescriptionText loadedProductData={loadedProductData} />

--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -28,8 +28,8 @@ import { getAuthManager } from '@/lib/firebase'
 import { toggleFittingRoomItem } from '@/lib/fitting-room-storage'
 import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
-import type { VtoProductData, VtoSizeColorData, VtoSizeData } from '@/lib/product'
-import { loadProductDataToStore } from '@/lib/product'
+import type { LoadedProductData, VtoProductData, VtoSizeColorData, VtoSizeData } from '@/lib/product'
+import { buildVtoWireItems, loadProductDataToStore } from '@/lib/product'
 import { loadStyleCategoryIndex } from '@/lib/style-categories'
 import { getStaticData, useMainStore } from '@/lib/store'
 import type { CssProp, StyleProp } from '@/lib/theme'
@@ -253,14 +253,39 @@ export default function QuickViewOverlay() {
     return { sizeColorRecord, availableColorLabels }
   }, [vtoProductData, selectedSizeLabel, selectedColorLabel])
 
+  // The loaded product data — pulled from the same store slot the
+  // setupInitialVtoData effect reads. Container products need it at
+  // wire-request time to expand into N child CSAs.
+  const loadedProduct = useMemo<LoadedProductData | null>(() => {
+    const { currentProduct } = getStaticData()
+    if (!currentProduct) {
+      return null
+    }
+    const entry = storeProductData[currentProduct.externalId]
+    if (!entry || 'error' in entry) {
+      return null
+    }
+    return entry
+  }, [storeProductData])
+
   // Request VTO for a color/size as a one-item outfit. Dedup, the prefetch
   // throttle, and frame storage all live in the shared useVtoRequests hook;
-  // single-garment compositions are never untucked.
+  // single-garment compositions are never untucked. Container products fan
+  // out at wire-build time via buildVtoWireItems; buildVtoWireItems returns
+  // null when the container's mapping is incomplete and we skip the request
+  // rather than post a broken composition.
   const requestVto = useCallback(
     (sizeColorRecord: VtoSizeColorData, priority: boolean) => {
-      vtoRequest([{ colorway_size_asset_id: sizeColorRecord.colorwaySizeAssetId, untucked: false }], priority)
+      if (!loadedProduct) {
+        return
+      }
+      const wireItems = buildVtoWireItems(loadedProduct, sizeColorRecord.colorwaySizeAssetId, false)
+      if (!wireItems) {
+        return
+      }
+      vtoRequest(wireItems, priority)
     },
-    [vtoRequest],
+    [vtoRequest, loadedProduct],
   )
 
   // Trigger priority VTO request when size/color selection changes
@@ -290,14 +315,18 @@ export default function QuickViewOverlay() {
 
   // Frame URLs for the currently-selected color/size: ask the shared hook
   // for this one-item outfit's rendered frames (already base-URL-rewritten),
-  // then preload the images.
+  // then preload the images. For containers the outfit key is the expanded
+  // set of child CSAs — same as what requestVto posted, so the hook's
+  // per-outfit frames Map has an entry keyed off the same wire shape.
   const frameUrls = useMemo(() => {
-    if (!selectedColorSizeRecord) {
+    if (!selectedColorSizeRecord || !loadedProduct) {
       return null
     }
-    const rewritten = framesForOutfit([
-      { colorway_size_asset_id: selectedColorSizeRecord.colorwaySizeAssetId, untucked: false },
-    ])
+    const wireItems = buildVtoWireItems(loadedProduct, selectedColorSizeRecord.colorwaySizeAssetId, false)
+    if (!wireItems) {
+      return null
+    }
+    const rewritten = framesForOutfit(wireItems)
     if (!rewritten) {
       return null
     }
@@ -307,7 +336,7 @@ export default function QuickViewOverlay() {
       img.src = url
     })
     return rewritten
-  }, [selectedColorSizeRecord, framesForOutfit])
+  }, [selectedColorSizeRecord, framesForOutfit, loadedProduct])
 
   const handleSignOutClick = useCallback(() => {
     closeOverlay()

--- a/src/lib/fitting-room-data.ts
+++ b/src/lib/fitting-room-data.ts
@@ -8,7 +8,7 @@ import type {
   VtoSizeColorData,
   VtoSizeData,
 } from '@/lib/product'
-import { loadProductDataToStore } from '@/lib/product'
+import { loadProductDataToStore, resolveContainerExpansion } from '@/lib/product'
 import type { ExternalProduct, MerchantProductError } from '@/lib/store'
 import { getStaticData, useMainStore } from '@/lib/store'
 import type { StyleCategory, StyleCategoryGroup, StyleCategoryIndex } from '@/lib/style-categories'
@@ -17,6 +17,17 @@ import { getSizeLabelFromSize } from '@/lib/util'
 
 const logger = getLogger('fitting-room-data')
 
+// Per-item effective (category, group) pairs. For single-garment items this
+// is `[(item's own category, its group)]`; for container products it's one
+// entry per child. The container category itself does NOT participate — it's
+// a wrapper, not a garment category — so pairwise composition checks and
+// garment-count arithmetic both key off this list. Emptied when the style
+// category index isn't loaded yet or the category name isn't known to it.
+export interface EffectiveCategory {
+  category: StyleCategory
+  group: StyleCategoryGroup | null
+}
+
 export interface ResolvedFittingRoomItem {
   externalId: string
   storage: FittingRoomItem
@@ -24,8 +35,13 @@ export interface ResolvedFittingRoomItem {
   merchantError: Error | null
   loadedProduct: LoadedProductData | null
   loadedError: Error | null
+  // styleCategory / styleCategoryGroup are the PARENT's (or single-garment
+  // item's own) category. Preserved for existing UI callsites (rail-card
+  // header, accordion group). For composition rules and cap arithmetic use
+  // `effective` below — that walks children for containers.
   styleCategory: StyleCategory | null
   styleCategoryGroup: StyleCategoryGroup | null
+  effective: EffectiveCategory[]
   isReady: boolean
   needsResize: boolean
 }
@@ -146,10 +162,26 @@ function resolveItem(
 
   let styleCategory: StyleCategory | null = null
   let styleCategoryGroup: StyleCategoryGroup | null = null
+  const effective: EffectiveCategory[] = []
   if (loadedProduct && index) {
     const categoryName = String(loadedProduct.style.style_category_name)
     styleCategory = index.byName(categoryName)
     styleCategoryGroup = index.groupForCategory(categoryName)
+    // Effective category set drives composition rules + garment-count cap.
+    // Containers expand to one entry per child; the container's own
+    // category (`suits_and_sets`) is a wrapper and does NOT participate.
+    // Single-garment items contribute their own category.
+    if (loadedProduct.container) {
+      for (const child of loadedProduct.container.children) {
+        const childName = String(child.style_category_name)
+        const childCat = index.byName(childName)
+        if (childCat) {
+          effective.push({ category: childCat, group: index.groupForCategory(childName) })
+        }
+      }
+    } else if (styleCategory) {
+      effective.push({ category: styleCategory, group: styleCategoryGroup })
+    }
   }
 
   // needsResize: csa is null OR csa is no longer in the current size rec.
@@ -174,6 +206,21 @@ function resolveItem(
         needsResize = true
       }
     }
+    // Container-specific: the stored parent CSA may still be in size-rec
+    // but the merchant might have deleted the corresponding set_size_mappings
+    // rows between sessions. Attempt the expansion and mark needsResize if
+    // it fails — surfacing the "pick a size" affordance is a better UX than
+    // silently dropping the item at wire-build time.
+    if (!needsResize && loadedProduct.container && item.colorwaySizeAssetId != null) {
+      const expanded = resolveContainerExpansion(loadedProduct, item.colorwaySizeAssetId)
+      if (!expanded) {
+        needsResize = true
+        logger.logDebug('container mapping resolved to empty, marking needsResize', {
+          externalId: item.externalId,
+          csa: item.colorwaySizeAssetId,
+        })
+      }
+    }
   }
 
   const isReady = !!merchantProduct && !!loadedProduct && !!styleCategory && !needsResize
@@ -187,6 +234,7 @@ function resolveItem(
     loadedError,
     styleCategory,
     styleCategoryGroup,
+    effective,
     isReady,
     needsResize,
   }

--- a/src/lib/fitting-room-data.ts
+++ b/src/lib/fitting-room-data.ts
@@ -59,6 +59,16 @@ export interface ResolvedFittingRoom {
   styleCategoryError: Error | null
 }
 
+// isItemTuckable returns true when at least one of the item's effective
+// categories carries tuckable=true. For single-garment items this reduces to
+// the item's own category; for containers it's true when any child garment
+// is tuckable (shirt in a suit set, etc). Prefer this helper over reading
+// `item.styleCategory.tuckable` directly — the latter is the PARENT
+// category's flag, which is always falsy for containers.
+export function isItemTuckable(item: ResolvedFittingRoomItem): boolean {
+  return item.effective.some((e) => !!e.category.tuckable)
+}
+
 // loadFittingRoomData fans out all the per-item lookups required to render
 // the fitting-room overlay. Idempotent: existing entries in the store are
 // not re-fetched; missing handles are reported as per-item errors.

--- a/src/lib/fitting-room-outfit.ts
+++ b/src/lib/fitting-room-outfit.ts
@@ -1,5 +1,6 @@
 import type { StyleCategory, StyleCategoryGroup } from '@/api/gen/responses'
 import type { ResolvedFittingRoom, ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
+import { isItemTuckable } from '@/lib/fitting-room-data'
 import { resolveContainerExpansion } from '@/lib/product'
 
 export type Availability = 'available' | 'selected' | 'disabled'
@@ -216,8 +217,18 @@ function makeOutfitItem(r: ResolvedFittingRoomItem, forceUntuck: boolean): Outfi
   if (r.storage.colorwaySizeAssetId == null) {
     return null
   }
-  const tuckable = !!r.styleCategory.tuckable
+  // Tuckable is a per-CHILD trait; the container's own category
+  // (suits_and_sets) is a wrapper and never tuckable. isItemTuckable walks
+  // effective categories so a Set with a tuckable shirt correctly picks up
+  // outfit-wide forceUntuck.
+  const tuckable = isItemTuckable(r)
   const untucked = forceUntuck && tuckable
+  // Layer order for the wrapper OutfitItem: single-garment uses the item's
+  // own layer, containers use the parent's — but the parent's layer_order
+  // fields are 0 (container category has no meaningful layer). That's fine:
+  // wire-time expansion re-orders per child on the backend before sending
+  // to sim-vis, so the OutfitItem-level layerOrder only controls the
+  // sort within `entries` (deterministic, stable for equivalent selections).
   const layerOrder = untucked ? r.styleCategory.layer_order_untucked : r.styleCategory.layer_order
   // Container products: resolve the N child CSAs the shopper's (parent CSA)
   // selection expands to, and attach so toWireItems can flatten. Drop the

--- a/src/lib/fitting-room-outfit.ts
+++ b/src/lib/fitting-room-outfit.ts
@@ -4,7 +4,24 @@ import { resolveContainerExpansion } from '@/lib/product'
 
 export type Availability = 'available' | 'selected' | 'disabled'
 
+// MAX_OUTFIT_ITEMS caps GARMENTS (not products) in an outfit — matches the
+// backend + sim-vis wire cap of 4 items on /v1/vto-compositions. A container
+// product's garment count is its children.length (via item.effective.length),
+// so a 3-piece Set consumes 3 slots and adding a fifth garment (of any shape)
+// hits the cap.
 export const MAX_OUTFIT_ITEMS = 4
+
+// Garment count per resolved item: containers contribute one per child (via
+// EffectiveCategory list); single-garment items contribute 1. Returns 0
+// when the style-category index hasn't populated yet — treating an
+// unresolved item as weightless is safer than blocking the add, and the
+// isReady flag on the caller handles the display-time skip.
+function getGarmentCount(item: ResolvedFittingRoomItem): number {
+  if (item.effective.length > 0) {
+    return item.effective.length
+  }
+  return item.styleCategory ? 1 : 0
+}
 
 export interface OutfitItem {
   externalId: string
@@ -43,6 +60,24 @@ function asStringList(value: unknown): string[] {
 
 function catName(c: StyleCategory): string {
   return String(c.name)
+}
+
+// itemsCompatible returns true if `a` and `b` can coexist in the same outfit,
+// considering each item's EFFECTIVE categories (children for containers, self
+// for single-garment). Fails if any A-child × B-child pair is incompatible
+// under pairCompatible.
+export function itemsCompatible(a: ResolvedFittingRoomItem, b: ResolvedFittingRoomItem): boolean {
+  if (a.effective.length === 0 || b.effective.length === 0) {
+    return true
+  }
+  for (const ae of a.effective) {
+    for (const be of b.effective) {
+      if (!pairCompatible(ae.category, be.category, ae.group)) {
+        return false
+      }
+    }
+  }
+  return true
 }
 
 // pairCompatible returns true if `a` and `b` can coexist in the same outfit.
@@ -127,13 +162,16 @@ export function computeAvailability(
   // Same-category items would be silently evicted on add. Treat them as
   // freed slots when computing effective outfit size and when checking
   // pair-compatibility — they're about to leave the outfit anyway.
+  //
+  // Same-category conflict keys on the PARENT category (so Set-vs-Set
+  // silent-swaps, and Pants-vs-Pants silent-swaps). Set-vs-standalone-Pants
+  // does not silent-swap even when the Set includes pants — the pairwise
+  // check below catches that as an incompatible add.
   const sameCategoryEvictions = new Set(getSameCategoryConflicts(item, selectedExternalIds, resolved))
-  const effectiveSize = selectedExternalIds.size - sameCategoryEvictions.size + 1
-  if (effectiveSize > MAX_OUTFIT_ITEMS) {
-    return 'disabled'
-  }
 
-  const itemCat = item.styleCategory
+  // Garment-count cap: sum children per selected item, plus the new item's
+  // own garment count. Containers count as N.
+  let effectiveGarments = getGarmentCount(item)
   for (const sel of resolved.items) {
     if (!selectedExternalIds.has(sel.externalId)) {
       continue
@@ -141,10 +179,20 @@ export function computeAvailability(
     if (sameCategoryEvictions.has(sel.externalId)) {
       continue
     }
-    if (!sel.styleCategory) {
+    effectiveGarments += getGarmentCount(sel)
+  }
+  if (effectiveGarments > MAX_OUTFIT_ITEMS) {
+    return 'disabled'
+  }
+
+  for (const sel of resolved.items) {
+    if (!selectedExternalIds.has(sel.externalId)) {
       continue
     }
-    if (!pairCompatible(sel.styleCategory, itemCat, sel.styleCategoryGroup)) {
+    if (sameCategoryEvictions.has(sel.externalId)) {
+      continue
+    }
+    if (!itemsCompatible(sel, item)) {
       return 'disabled'
     }
   }
@@ -154,6 +202,11 @@ export function computeAvailability(
 interface OutfitBuilderEntry {
   outfitItem: OutfitItem
   layerOrder: number
+  // Garment count this OutfitItem contributes to the wire request — 1 for
+  // single-garment items, N for containers (childCsaIds.length). Kept
+  // alongside layerOrder so the final MAX_OUTFIT_ITEMS trim can enforce
+  // the cap on the wire-item count that will actually go to sim-vis.
+  garmentCount: number
 }
 
 function makeOutfitItem(r: ResolvedFittingRoomItem, forceUntuck: boolean): OutfitBuilderEntry | null {
@@ -185,7 +238,7 @@ function makeOutfitItem(r: ResolvedFittingRoomItem, forceUntuck: boolean): Outfi
     ...(untucked ? { untucked: true as const } : {}),
     ...(childCsaIds ? { childCsaIds } : {}),
   }
-  return { outfitItem, layerOrder }
+  return { outfitItem, layerOrder, garmentCount: childCsaIds?.length ?? 1 }
 }
 
 // buildOutfit derives the wire-shape outfit (1..4 items, layer-ordered) plus a
@@ -215,7 +268,20 @@ export function buildOutfit(
   }
 
   entries.sort((a, b) => a.layerOrder - b.layerOrder)
-  const items = entries.slice(0, MAX_OUTFIT_ITEMS).map((e) => e.outfitItem)
+  // Trim by garment count, not entry count: a 3-piece Set fills 3 wire
+  // slots. computeAvailability blocks the add before we get here, but this
+  // defensive slice keeps a stale selection from posting > 4 garments (e.g.
+  // if the merchant's container-child count changed since the shopper
+  // selected it).
+  const items: OutfitItem[] = []
+  let cumulativeGarments = 0
+  for (const entry of entries) {
+    if (cumulativeGarments + entry.garmentCount > MAX_OUTFIT_ITEMS) {
+      break
+    }
+    items.push(entry.outfitItem)
+    cumulativeGarments += entry.garmentCount
+  }
 
   const alternates = buildAlternateOutfits(items, lastAddedResolved)
   return { items, alternates }

--- a/src/lib/fitting-room-outfit.ts
+++ b/src/lib/fitting-room-outfit.ts
@@ -1,5 +1,6 @@
 import type { StyleCategory, StyleCategoryGroup } from '@/api/gen/responses'
 import type { ResolvedFittingRoom, ResolvedFittingRoomItem } from '@/lib/fitting-room-data'
+import { resolveContainerExpansion } from '@/lib/product'
 
 export type Availability = 'available' | 'selected' | 'disabled'
 
@@ -9,6 +10,13 @@ export interface OutfitItem {
   externalId: string
   colorwaySizeAssetId: number
   untucked?: true
+  /**
+   * For container (Suits & Sets) products: pre-resolved child CSA ids the SDK
+   * will emit as separate items[] entries when the wire request is built.
+   * Undefined for single-garment products. Populated at OutfitItem
+   * construction time from the resolved loadedProduct's container data.
+   */
+  childCsaIds?: number[]
 }
 
 export interface Outfit {
@@ -158,10 +166,24 @@ function makeOutfitItem(r: ResolvedFittingRoomItem, forceUntuck: boolean): Outfi
   const tuckable = !!r.styleCategory.tuckable
   const untucked = forceUntuck && tuckable
   const layerOrder = untucked ? r.styleCategory.layer_order_untucked : r.styleCategory.layer_order
+  // Container products: resolve the N child CSAs the shopper's (parent CSA)
+  // selection expands to, and attach so toWireItems can flatten. Drop the
+  // whole item when expansion fails — a container with a broken mapping
+  // cannot render, and sending the parent CSA alone would 400 downstream
+  // (the backend rejects parent CSAs as VTO items).
+  let childCsaIds: number[] | undefined
+  if (r.loadedProduct?.container) {
+    const resolved = resolveContainerExpansion(r.loadedProduct, r.storage.colorwaySizeAssetId)
+    if (!resolved) {
+      return null
+    }
+    childCsaIds = resolved
+  }
   const outfitItem: OutfitItem = {
     externalId: r.externalId,
     colorwaySizeAssetId: r.storage.colorwaySizeAssetId,
     ...(untucked ? { untucked: true as const } : {}),
+    ...(childCsaIds ? { childCsaIds } : {}),
   }
   return { outfitItem, layerOrder }
 }
@@ -237,8 +259,26 @@ export function buildAlternateOutfits(
     if (!altCsa) {
       continue
     }
+    // Container products: the alt is the same set at a different set-size;
+    // re-resolve the N child CSAs at the new (parent size, colorway).
+    // Skip the alt entirely if the merchant's mapping doesn't cover the alt
+    // set-size — half-mapped containers shouldn't produce a broken prefetch.
+    let altChildCsaIds: number[] | undefined
+    if (lastAddedResolved.loadedProduct.container) {
+      const resolved = resolveContainerExpansion(lastAddedResolved.loadedProduct, altCsa.id)
+      if (!resolved) {
+        continue
+      }
+      altChildCsaIds = resolved
+    }
     const alternate = primary.map((it) =>
-      it.externalId === lastAddedResolved.externalId ? { ...it, colorwaySizeAssetId: altCsa.id } : it,
+      it.externalId === lastAddedResolved.externalId
+        ? {
+            ...it,
+            colorwaySizeAssetId: altCsa.id,
+            ...(altChildCsaIds ? { childCsaIds: altChildCsaIds } : {}),
+          }
+        : it,
     )
     out.push(alternate)
   }

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -4,7 +4,13 @@ import type {
   FirestoreSetSizeMapping,
   FirestoreSize,
 } from '@/api/gen/responses'
-import type { FitClassification, MeasurementLocationFit, SizeFit, SizeFitRecommendation } from '@/lib/api'
+import type {
+  FitClassification,
+  MeasurementLocationFit,
+  SizeFit,
+  SizeFitRecommendation,
+  VtoCompositionItem,
+} from '@/lib/api'
 import { getSizeRecommendation as apiGetSizeRecommendation } from '@/lib/api'
 import type { FirestoreStyle } from '@/lib/database'
 import { getStyleByExternalId } from '@/lib/database'
@@ -113,6 +119,59 @@ export async function loadProductData(externalId: string): Promise<LoadedProduct
     sizeFitRecommendation,
     container,
   }
+}
+
+/**
+ * buildVtoWireItems is the shared helper for callsites that build a single
+ * product's wire-request items from a chosen parent CSA. Returns 1 wire item
+ * for single-garment products; N items for containers (one per expanded
+ * child CSA, with `untucked` propagated to every entry).
+ *
+ * Returns null when the product is a container but expansion fails — caller
+ * should skip the request rather than post an item pointing at the parent
+ * CSA (backend rejects parent CSAs as VTO items).
+ */
+export function buildVtoWireItems(
+  loaded: LoadedProductData,
+  parentCsaId: number,
+  untucked: boolean,
+): VtoCompositionItem[] | null {
+  const untuckFrag = untucked ? { untucked: true as const } : {}
+  if (!loaded.container) {
+    return [{ colorway_size_asset_id: parentCsaId, ...untuckFrag }]
+  }
+  const childCsaIds = resolveContainerExpansion(loaded, parentCsaId)
+  if (!childCsaIds) {
+    return null
+  }
+  return childCsaIds.map((csaId) => ({ colorway_size_asset_id: csaId, ...untuckFrag }))
+}
+
+/**
+ * resolveContainerExpansion is the convenience wrapper for the wire-request
+ * build path: given a loaded product and the shopper's chosen parent CSA id,
+ * look up which parent Size + colorway that CSA belongs to (via the size-rec
+ * response, which the SDK has cached at load time) and then walk the mappings
+ * to N child CSAs.
+ *
+ * Returns null when the style isn't a container, when the parent CSA can't
+ * be located on any size-rec row (stale storage), or when child expansion
+ * fails (see resolveContainerChildCSAs). Callers treat null as "post the
+ * single parent CSA as-is" (non-container path) OR "skip this outfit item"
+ * (broken container), depending on which case null represents.
+ */
+export function resolveContainerExpansion(loaded: LoadedProductData, parentCsaId: number): number[] | null {
+  if (!loaded.container) {
+    return null
+  }
+  for (const sz of loaded.sizeFitRecommendation.available_sizes) {
+    const csa = sz.colorway_size_assets.find((c) => c.id === parentCsaId)
+    if (!csa || !csa.colorway_name) {
+      continue
+    }
+    return resolveContainerChildCSAs(loaded.container, sz.id, csa.colorway_name)
+  }
+  return null
 }
 
 /**

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -1,3 +1,9 @@
+import type {
+  FirestoreChildStyle,
+  FirestoreColorwaySizeAsset,
+  FirestoreSetSizeMapping,
+  FirestoreSize,
+} from '@/api/gen/responses'
 import type { FitClassification, MeasurementLocationFit, SizeFit, SizeFitRecommendation } from '@/lib/api'
 import { getSizeRecommendation as apiGetSizeRecommendation } from '@/lib/api'
 import type { FirestoreStyle } from '@/lib/database'
@@ -9,10 +15,29 @@ export type { FitClassification, MeasurementLocationFit, SizeFit, SizeFitRecomme
 
 export type Style = FirestoreStyle
 
+// Container-style narrowed views. Tygo emits FirestoreStyle.children /
+// set_size_mappings as `any[]` because Go's ToFirestoreStruct declares
+// them as `[]interface{}` — but the runtime shape is
+// FirestoreChildStyle[] / FirestoreSetSizeMapping[] respectively. Same
+// story for the sibling embedded arrays (children[].sizes,
+// children[].colorway_size_assets), which are structured but come
+// through as `any[]`. Everything below assumes that runtime shape.
+type FirestoreChildStyleWithNested = FirestoreChildStyle & {
+  sizes?: FirestoreSize[]
+  colorway_size_assets?: FirestoreColorwaySizeAsset[]
+}
+
+export interface ContainerStyleData {
+  children: FirestoreChildStyleWithNested[]
+  setSizeMappings: FirestoreSetSizeMapping[]
+}
+
 export interface LoadedProductData {
   externalId: string
   style: Style
   sizeFitRecommendation: SizeFitRecommendation
+  /** Populated only when style.is_container === true. */
+  container?: ContainerStyleData
 }
 export interface LoadedProductError {
   externalId: string
@@ -75,11 +100,68 @@ export async function loadProductData(externalId: string): Promise<LoadedProduct
 
   const sizeFitRecommendation = await apiGetSizeRecommendation(style.id)
 
+  const container = style.is_container
+    ? {
+        children: (style.children as FirestoreChildStyleWithNested[] | undefined) ?? [],
+        setSizeMappings: (style.set_size_mappings as FirestoreSetSizeMapping[] | undefined) ?? [],
+      }
+    : undefined
+
   return {
     externalId,
     style,
     sizeFitRecommendation,
+    container,
   }
+}
+
+/**
+ * resolveContainerChildCSAs walks the container's set_size_mappings and each
+ * child's embedded sizes/colorway_size_assets to expand a shopper-selected
+ * (parent size id, colorway id) into one child CSA id per component.
+ *
+ * Colorway resolution: parent colorway names are mirrored onto each child at
+ * publish time (backend hook), so match a child's CSA by the parent-colorway
+ * NAME rather than the parent colorway id — child colorways have their own
+ * ids.
+ *
+ * Returns null if any child is missing a mapping or a matching CSA; the caller
+ * treats null as "cannot render this container at the shopper's selection",
+ * which usually means the merchant has an in-flight edit that broke coverage.
+ */
+export function resolveContainerChildCSAs(
+  container: ContainerStyleData,
+  parentSizeId: number,
+  parentColorwayName: string,
+): number[] | null {
+  const relevantMappings = container.setSizeMappings.filter((m) => m.parent_size_id === parentSizeId)
+  if (relevantMappings.length === 0) {
+    return null
+  }
+  const csaIds: number[] = []
+  for (const mapping of relevantMappings) {
+    // Find the child that owns this child_size_id. Each child's sizes[]
+    // is small (2-3 entries typical) so a nested find is fine.
+    let matchedCsaId: number | null = null
+    for (const child of container.children) {
+      const size = (child.sizes ?? []).find((s) => s.id === mapping.child_size_id)
+      if (!size) {
+        continue
+      }
+      const csa = (child.colorway_size_assets ?? []).find(
+        (a) => a.size_id === size.id && a.colorway_name === parentColorwayName,
+      )
+      if (csa) {
+        matchedCsaId = csa.id
+      }
+      break
+    }
+    if (matchedCsaId == null) {
+      return null
+    }
+    csaIds.push(matchedCsaId)
+  }
+  return csaIds
 }
 
 export function loadProductDataToStore(externalId: string): void {

--- a/tests/e2e/container-vto.spec.ts
+++ b/tests/e2e/container-vto.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+import {
+  TEST_CONTAINER_CHILD_PANTS_CSA_ID,
+  TEST_CONTAINER_CHILD_SHIRT_CSA_ID,
+  TEST_CONTAINER_CURRENT_PRODUCT,
+  TEST_CONTAINER_PARENT_CSA_ID,
+  TEST_CONTAINER_SEEDED_STYLE,
+  TEST_CONTAINER_SIZE_FIT_RECOMMENDATION,
+  TEST_VTO_COMPOSITION_12,
+} from './fixtures/seed'
+
+// End-to-end coverage for container (Suits & Sets) VTO expansion. Wire
+// contract for /v1/vto-compositions is unchanged (1..4 leaf-garment items);
+// containers require the SDK to fan out the shopper's one parent-CSA
+// selection into N leaf-CSA items[] entries before posting. This test
+// intercepts the composition POST body and asserts on the wire shape.
+//
+// The critical bug this guards against: SDK regresses to posting the parent
+// CSA id (backend rejects it — parents have no .usdz), or the resolver walks
+// the wrong colorway and posts stale/missing child ids.
+
+test('quick-view container: POST /v1/vto-compositions carries child CSAs, not the parent CSA', async ({ page }) => {
+  const capturedRequests: Array<{ colorway_size_asset_id: number; untucked?: boolean }[]> = []
+
+  await bootSdk(page, {
+    currentProduct: TEST_CONTAINER_CURRENT_PRODUCT,
+    apiOverrides: {
+      sizeRecommendation: (route) => route.fulfill({ json: TEST_CONTAINER_SIZE_FIT_RECOMMENDATION }),
+      vtoComposition: async (route) => {
+        // Capture the wire shape sent by the SDK, then fulfill with the
+        // standard 12-frame VTO response so the UI has something to render.
+        const body = route.request().postDataJSON() as { items: (typeof capturedRequests)[number] }
+        capturedRequests.push(body.items)
+        await route.fulfill({ json: TEST_VTO_COMPOSITION_12 })
+      },
+    },
+    firestoreDocs: { styles: { 'container-style-1': TEST_CONTAINER_SEEDED_STYLE } },
+  })
+  await page.getByRole('button', { name: /quick view/i }).click()
+
+  // Wait for the composition POST to fire.
+  await expect.poll(() => capturedRequests.length, { timeout: 5000 }).toBeGreaterThanOrEqual(1)
+
+  const items = capturedRequests[0]
+  expect(items).toHaveLength(2)
+  const emittedCsaIds = items.map((i) => i.colorway_size_asset_id).sort((a, b) => a - b)
+  expect(emittedCsaIds).toEqual(
+    [TEST_CONTAINER_CHILD_SHIRT_CSA_ID, TEST_CONTAINER_CHILD_PANTS_CSA_ID].sort((a, b) => a - b),
+  )
+
+  // Explicitly assert the parent CSA is NOT in the wire request — if it
+  // ever appears, the resolver has regressed to no-op / bypass.
+  expect(emittedCsaIds).not.toContain(TEST_CONTAINER_PARENT_CSA_ID)
+})

--- a/tests/e2e/container-vto.spec.ts
+++ b/tests/e2e/container-vto.spec.ts
@@ -52,4 +52,9 @@ test('quick-view container: POST /v1/vto-compositions carries child CSAs, not th
   // Explicitly assert the parent CSA is NOT in the wire request — if it
   // ever appears, the resolver has regressed to no-op / bypass.
   expect(emittedCsaIds).not.toContain(TEST_CONTAINER_PARENT_CSA_ID)
+
+  // Wire item count must never exceed 4 (backend + sim-vis cap). A 2-piece
+  // Set alone shouldn't approach it, but this locks in the invariant the
+  // Phase B garment-count cap enforces client-side.
+  expect(items.length).toBeLessThanOrEqual(4)
 })

--- a/tests/e2e/fixtures/seed.ts
+++ b/tests/e2e/fixtures/seed.ts
@@ -127,3 +127,146 @@ export const TEST_SEEDED_STYLE = {
   external_id: TEST_PRODUCT_EXTERNAL_ID,
   style_category_name: 'tshirt',
 }
+
+// --- Container (Suits & Sets) fixture -------------------------------------
+// A minimal 2-piece container: 1 set-size, 1 colorway, 1 parent CSA on the
+// shopper side; 2 children (shirt + pants) each with 1 leaf size + 1 leaf
+// CSA in the shared "default" colorway. set_size_mappings ties them
+// together. Used by container-vto.spec.ts to verify the SDK's expansion
+// posts N leaf CSAs to /v1/vto-compositions instead of the 1 parent CSA.
+
+export const TEST_CONTAINER_STYLE_ID = 998
+export const TEST_CONTAINER_EXTERNAL_ID = 'gid://shopify/Product/54321'
+export const TEST_CONTAINER_HANDLE = 'test-container'
+
+// Ids used across the fixture. Kept as named constants so the wire
+// assertion in the spec reads "expect CSA 8001 and 8002" rather than
+// magic numbers.
+export const TEST_CONTAINER_PARENT_SIZE_ID = 6100
+export const TEST_CONTAINER_PARENT_CSA_ID = 6001
+export const TEST_CONTAINER_CHILD_SHIRT_SIZE_ID = 7001
+export const TEST_CONTAINER_CHILD_SHIRT_CSA_ID = 8001
+export const TEST_CONTAINER_CHILD_PANTS_SIZE_ID = 7002
+export const TEST_CONTAINER_CHILD_PANTS_CSA_ID = 8002
+
+// Shopify-side product: one variant per set-size × color. SKU matches the
+// parent CSA's SKU below so quick-view's setupInitialVtoData picks it up.
+export const TEST_CONTAINER_CURRENT_PRODUCT = {
+  productName: 'Test Suit Set',
+  productDescriptionHtml: '<p>Two-piece test set</p>',
+  externalId: TEST_CONTAINER_EXTERNAL_ID,
+  handle: TEST_CONTAINER_HANDLE,
+  imageUrl: null,
+  variants: [
+    {
+      sku: 'SET-M32-DEFAULT',
+      size: 'M/32',
+      color: 'Default',
+      fullName: 'Test Set M/32 Default',
+      skuName: 'SET-M32-DEFAULT',
+      priceFormatted: '$200.00',
+      imageUrl: null,
+    },
+  ],
+}
+
+// Size-rec for the container parent: one set-size row with one parent CSA.
+// The parent CSA carries colorway_name so the SDK's resolver can key child
+// CSAs by name (children mirror the parent's colorway name at publish time).
+export const TEST_CONTAINER_SIZE_FIT_RECOMMENDATION = {
+  fit_classification: 'regular_fit',
+  recommended_size: {
+    id: TEST_CONTAINER_PARENT_SIZE_ID,
+    label: 'M/32',
+    size_value: { value: 'M/32' },
+    colorway_size_assets: [
+      {
+        id: TEST_CONTAINER_PARENT_CSA_ID,
+        sku: 'SET-M32-DEFAULT',
+        colorway_id: 4100,
+        colorway_name: 'default',
+      },
+    ],
+  },
+  available_sizes: [
+    {
+      id: TEST_CONTAINER_PARENT_SIZE_ID,
+      label: 'M/32',
+      size_value: { value: 'M/32' },
+      colorway_size_assets: [
+        {
+          id: TEST_CONTAINER_PARENT_CSA_ID,
+          sku: 'SET-M32-DEFAULT',
+          colorway_id: 4100,
+          colorway_name: 'default',
+        },
+      ],
+    },
+  ],
+  fits: [{ size_id: TEST_CONTAINER_PARENT_SIZE_ID, measurement_location_fits: [] }],
+}
+
+// Firestore-shape container style. Backend embeds is_container / children /
+// set_size_mappings on the parent doc when style.is_container is true.
+// children[].sizes and children[].colorway_size_assets are the leaf rows the
+// resolver walks. colorway_name on each child CSA MUST match the parent CSA's
+// colorway_name — that's the join key.
+export const TEST_CONTAINER_SEEDED_STYLE = {
+  id: TEST_CONTAINER_STYLE_ID,
+  brand_id: TEST_BRAND_ID,
+  external_id: TEST_CONTAINER_EXTERNAL_ID,
+  style_category_name: 'suits_and_sets',
+  is_container: true,
+  children: [
+    {
+      id: 501,
+      name: 'Shirt',
+      component_index: 0,
+      style_category_name: 'inner_tops',
+      style_category_label: 'Tops',
+      size_system_id: 1,
+      vertical_size_system_id: 0,
+      sizes: [{ id: TEST_CONTAINER_CHILD_SHIRT_SIZE_ID, label: 'M', size_value_id: 5 }],
+      colorway_size_assets: [
+        {
+          id: TEST_CONTAINER_CHILD_SHIRT_CSA_ID,
+          brand_id: TEST_BRAND_ID,
+          size_id: TEST_CONTAINER_CHILD_SHIRT_SIZE_ID,
+          style_id: 501,
+          colorway_id: 5100,
+          colorway_name: 'default',
+          sku: '',
+          folder_storage_path: '',
+          asset_container_name: '',
+        },
+      ],
+    },
+    {
+      id: 502,
+      name: 'Pants',
+      component_index: 1,
+      style_category_name: 'bottoms',
+      style_category_label: 'Bottoms',
+      size_system_id: 2,
+      vertical_size_system_id: 2,
+      sizes: [{ id: TEST_CONTAINER_CHILD_PANTS_SIZE_ID, label: '32/32', size_value_id: 48 }],
+      colorway_size_assets: [
+        {
+          id: TEST_CONTAINER_CHILD_PANTS_CSA_ID,
+          brand_id: TEST_BRAND_ID,
+          size_id: TEST_CONTAINER_CHILD_PANTS_SIZE_ID,
+          style_id: 502,
+          colorway_id: 5200,
+          colorway_name: 'default',
+          sku: '',
+          folder_storage_path: '',
+          asset_container_name: '',
+        },
+      ],
+    },
+  ],
+  set_size_mappings: [
+    { parent_size_id: TEST_CONTAINER_PARENT_SIZE_ID, child_size_id: TEST_CONTAINER_CHILD_SHIRT_SIZE_ID },
+    { parent_size_id: TEST_CONTAINER_PARENT_SIZE_ID, child_size_id: TEST_CONTAINER_CHILD_PANTS_SIZE_ID },
+  ],
+}


### PR DESCRIPTION
## Summary

SDK side of the Suits & Sets feature. Adds container-product (multi-piece Set) support end-to-end: Firestore load, VTO wire expansion, outfit-level rules, PDP tuck toggle.

Wire contract for `/v1/vto-compositions` is unchanged (1..4 leaf-garment items). The SDK is the single expansion point: at wire-build the shopper's selected parent CSA is replaced by N leaf CSAs resolved from the container's `set_size_mappings` at the current (parent size, colorway). Storage stays untouched — `FittingRoomItem` still holds only `{externalId, size, color, parentCsaId}`, so a merchant edit to mappings between sessions reaches the shopper on next composition without storage migration.

**Companion PRs:**
- [tfr-backend#847](https://github.com/TheFittingRoom/tfr-backend/pull/847) — schema, atomic style PUT/POST, Firestore snapshot.
- [dashboard#219](https://github.com/TheFittingRoom/dashboard/pull/219) — editor container mode + Templates + Sizes tab.

## What landed (bottom-up commit list)

**Phase A — Backend integration + wire expansion**

- **Regen tygo baseline** — pulls in all accumulated Suits & Sets backend contract changes (`is_container` / `children[]` / `set_size_mappings[]` on FirestoreStyle, sibling `FirestoreChildStyle` / `FirestoreSetSizeMapping`, atomic-write request shapes, template CRUD, placement column drop). No handwritten consumer changes in this commit.
- **`lib/product.ts`** — narrowed `ContainerStyleData` field on `LoadedProductData` (tygo emits the runtime arrays as `any[]` because Go's `ToFirestoreStruct` is `[]interface{}`). New helpers:
  - `resolveContainerChildCSAs(container, parentSizeId, parentColorwayName)` walks `set_size_mappings` + each child's `sizes[]` / `colorway_size_assets[]`. Colorway resolution matches by NAME (children mirror parent colorways at publish time with their own ids). Returns null when any child mapping/CSA is missing.
  - `resolveContainerExpansion(loaded, parentCsaId)` locates the shopper's chosen (size × colorway) via the cached size-rec response and delegates.
  - `buildVtoWireItems(loaded, parentCsaId, untucked)` shared helper — 1 wire item for single-garment, N for containers, null when a container's mapping is incomplete.
- **Fitting-room path** (`lib/fitting-room-outfit.ts` + `overlays/fitting-room/index.tsx`) — `OutfitItem` gains optional `childCsaIds`, populated in `makeOutfitItem` from the resolved `loadedProduct.container`. `buildAlternateOutfits` re-resolves per swap (each alt is the same set at a different set-size). `toWireItems` flatMaps: children when present, single CSA otherwise; `untucked` propagates uniformly. Broken mappings drop the item rather than emit a parent CSA (backend rejects those).
- **Quick-view path** (`overlays/quick-view.tsx`) — both `requestVto` and `frameUrls` pull the loaded product from `storeProductData` and route through `buildVtoWireItems`. Broken mappings → no request / no frames.
- **e2e** — `container-vto.spec.ts` intercepts the `/v1/vto-compositions` POST body and asserts `items[]` carries the child CSAs (not the parent CSA), also caps `items.length <= 4`. Regression check for the wire shape.

**Phase B — Outfit-level correctness**

- **`ResolvedFittingRoomItem.effective: EffectiveCategory[]`** — per-child (category, group) pairs for containers, self for single-garment. Populated at `resolveItem` time from the style-category index. The container's own category (`suits_and_sets`) is a wrapper and does NOT participate.
- **Garment-count cap** — `MAX_OUTFIT_ITEMS = 4` now means "4 wire garments" (matches backend + sim-vis). `computeAvailability` sums `effective.length` per selected item; `buildOutfit` trims by cumulative garment count. A 3-piece Set consumes 3 slots; adding a 5th garment hits the cap.
- **`itemsCompatible`** replaces the direct `pairCompatible` call — walks A-effective × B-effective and fails if any pair is incompatible. Fixes the Set-with-pants + standalone-pants case that used to slip through (parent `suits_and_sets` has empty includes/excludes).
- **`needsResize` container branch** — even when the stored parent CSA is still in size-rec, the merchant might have deleted `set_size_mappings` rows between sessions. Attempts the expansion; marks `needsResize` on null so the shopper sees the "pick a size" affordance rather than silent breakage at wire-build.

**Phase C — Tuck: per-child derivation + PDP toggle**

- **`isItemTuckable(item)`** helper — walks effective categories; returns true when any child garment is tuckable. Fixes two callers reading `item.styleCategory.tuckable` (the PARENT flag, always falsy for containers):
  1. `makeOutfitItem`'s `forceUntuck` propagation — a Set with a tuckable shirt now correctly picks up the outfit-level "try untucked" toggle.
  2. `detail-accordion-item`'s mobile tuck CTA — appears for containers with a tuckable child.
- **Quick-view PDP tuck toggle** (plan Q10):
  - `containerUntucked` state + handler in `QuickViewOverlay`.
  - `containerHasTuckableChild` memo (via `peekStyleCategoryIndex`).
  - `LayoutProps` grows `containerTuckable` / `containerUntucked` / `onToggleUntuck`.
  - Both `requestVto` and `frameUrls` pass `loadedProduct.container ? containerUntucked : false` into `buildVtoWireItems`.
  - New `ContainerTuckToggleButton` rendered in `DesktopLayout` beneath the fitting-room CTA. Mobile layouts don't receive the tuck props yet — flagged `TODO(container-tuck-mobile)`. Container tuck via the fitting-room accordion works on both platforms via the outfit-level path (fixed by the `isItemTuckable` change above).

## Not doing (deferred by design)

- **`FittingRoomItem` shape change** — decision was don't store children; re-derive on load. Always current, no storage migration, no invalidation surface. Storage stays `{externalId, size, color, parentCsaId, ...}`.
- **Rail card + accordion per-child sub-rows** (plan step 9) — no correctness path blocked; containers currently look like a single product on the rail. Follow up if merchant QA calls for it.
- **Alternate-outfit prefetch special-casing** — confirmed no fanout needed; same 2 alts as single-garment, expansion happens at wire-build.

## Test plan

- [ ] `npm run check` clean (tsc + eslint + prettier). ✅ verified locally.
- [ ] `npm run test:e2e` — all 7 tests green (existing 6 + new `container-vto`). ✅ verified locally.
- [ ] `npm run build` clean.
- [ ] Cold-start local stack + Shopify theme with `?tfr-source=local`; open quick-view on a container product; verify VTO composes and renders through the desktop tuck toggle path.
- [ ] Add a container product to the fitting room; verify it consumes N slots; add a 5th garment (single-garment) and verify it's disabled once total garments > 4.
- [ ] Add a Set with a tuckable child (shirt), toggle the accordion tuck CTA, verify the composition re-renders.
- [ ] Regressions: existing single-garment PDP + fitting-room flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)