### PR TITLE
Diagnostic: warn-log silent-null paths in container VTO expansion

### DIFF
--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -142,6 +142,10 @@ export function buildVtoWireItems(
   }
   const childCsaIds = resolveContainerExpansion(loaded, parentCsaId)
   if (!childCsaIds) {
+    logger.logWarn('buildVtoWireItems: container expansion failed, skipping request', {
+      externalId: loaded.externalId,
+      parentCsaId,
+    })
     return null
   }
   return childCsaIds.map((csaId) => ({ colorway_size_asset_id: csaId, ...untuckFrag }))
@@ -166,11 +170,28 @@ export function resolveContainerExpansion(loaded: LoadedProductData, parentCsaId
   }
   for (const sz of loaded.sizeFitRecommendation.available_sizes) {
     const csa = sz.colorway_size_assets.find((c) => c.id === parentCsaId)
-    if (!csa || !csa.colorway_name) {
+    if (!csa) {
       continue
     }
-    return resolveContainerChildCSAs(loaded.container, sz.id, csa.colorway_name)
+    if (!csa.colorway_name) {
+      logger.logWarn('resolveContainerExpansion: parent CSA has no colorway_name', {
+        externalId: loaded.externalId,
+        parentCsaId,
+        parentSizeId: sz.id,
+      })
+      continue
+    }
+    return resolveContainerChildCSAs(loaded.container, sz.id, csa.colorway_name, loaded.externalId)
   }
+  logger.logWarn('resolveContainerExpansion: parent CSA not found in any available_size', {
+    externalId: loaded.externalId,
+    parentCsaId,
+    availableSizeIds: loaded.sizeFitRecommendation.available_sizes.map((s) => s.id),
+    csaIdsBySize: loaded.sizeFitRecommendation.available_sizes.map((s) => ({
+      sizeId: s.id,
+      csaIds: s.colorway_size_assets.map((c) => c.id),
+    })),
+  })
   return null
 }
 
@@ -192,9 +213,16 @@ export function resolveContainerChildCSAs(
   container: ContainerStyleData,
   parentSizeId: number,
   parentColorwayName: string,
+  externalId?: string,
 ): number[] | null {
   const relevantMappings = container.setSizeMappings.filter((m) => m.parent_size_id === parentSizeId)
   if (relevantMappings.length === 0) {
+    logger.logWarn('resolveContainerChildCSAs: no set_size_mappings for parent size', {
+      externalId,
+      parentSizeId,
+      parentColorwayName,
+      mappingParentSizeIds: container.setSizeMappings.map((m) => m.parent_size_id),
+    })
     return null
   }
   const csaIds: number[] = []
@@ -202,11 +230,14 @@ export function resolveContainerChildCSAs(
     // Find the child that owns this child_size_id. Each child's sizes[]
     // is small (2-3 entries typical) so a nested find is fine.
     let matchedCsaId: number | null = null
-    for (const child of container.children) {
+    let ownerChildIdx: number | null = null
+    for (let i = 0; i < container.children.length; i++) {
+      const child = container.children[i]
       const size = (child.sizes ?? []).find((s) => s.id === mapping.child_size_id)
       if (!size) {
         continue
       }
+      ownerChildIdx = i
       const csa = (child.colorway_size_assets ?? []).find(
         (a) => a.size_id === size.id && a.colorway_name === parentColorwayName,
       )
@@ -216,6 +247,17 @@ export function resolveContainerChildCSAs(
       break
     }
     if (matchedCsaId == null) {
+      const owner = ownerChildIdx != null ? container.children[ownerChildIdx] : null
+      logger.logWarn('resolveContainerChildCSAs: no matching child CSA', {
+        externalId,
+        parentSizeId,
+        parentColorwayName,
+        childSizeId: mapping.child_size_id,
+        ownerChildIdx,
+        ownerChildFound: owner != null,
+        ownerColorwayNames: owner ? (owner.colorway_size_assets ?? []).map((a) => a.colorway_name) : [],
+        ownerChildSizeIds: owner ? (owner.sizes ?? []).map((s) => s.id) : [],
+      })
       return null
     }
     csaIds.push(matchedCsaId)


### PR DESCRIPTION
## Summary
- Container products no-op silently when the three-stage VTO expansion pipeline fails (`buildVtoWireItems` → `resolveContainerExpansion` → `resolveContainerChildCSAs`). Shopper sees no VTO render; nothing lands in the browser console. On the demo stack a container product opens the quick-view fine but never fires the composition request, and we're guessing at which of the six possible null-return paths is responsible.
- This patch adds targeted `warn`-level logs at each null-return branch so the failure can be identified from a single browser reload. Purely additive; no behavior change.

## Branches instrumented
1. `buildVtoWireItems` — expansion returned null.
2. `resolveContainerExpansion` — parent CSA absent from every `available_size` (dumps the CSA ids that WERE seen, so we can compare against the parent CSA id the shopper picked).
3. `resolveContainerExpansion` — parent CSA found but missing `colorway_name` (backend `Style.One` preloads `Sizes.ColorwaySizeAssets.Colorway`, so this should never happen; log confirms).
4. `resolveContainerChildCSAs` — no `set_size_mappings` for the parent size.
5. `resolveContainerChildCSAs` — mapping exists but no child owns the `child_size_id` OR the owning child's CSA rows don't include `(size_id, colorway_name)`. Log includes the owning child's `colorway_size_assets[].colorway_name` list so \"wrong colorway spelling\", \"missing CSA row\", and \"child not re-saved after edit\" are distinguishable.

## Follow-up

Once the demo reload identifies the failing branch, follow-up PR fixes the specific bug and (probably) drops most of these warns back down. Leaving them all as `logWarn` — not `logError` — since a broken container is a merchant-data problem, not an SDK bug.

## Test plan
- [ ] `npm run check` clean.
- [ ] Deploy, reload demo storefront `?tfr-source=local` with a container product, open browser console. Expect exactly one of the five warn shapes above to fire.
- [ ] Single-garment path unchanged (loaded.container check short-circuits before any of the new logs).