### PR TITLE
Fix double-HTML-escaped size labels + latched container tuck toggle

### DIFF
--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -30,7 +30,7 @@ import { useTranslation } from '@/lib/locale'
 import { getLogger } from '@/lib/logger'
 import type { LoadedProductData, VtoProductData, VtoSizeColorData, VtoSizeData } from '@/lib/product'
 import { buildVtoWireItems, loadProductDataToStore } from '@/lib/product'
-import { loadStyleCategoryIndex, peekStyleCategoryIndex } from '@/lib/style-categories'
+import { loadStyleCategoryIndex } from '@/lib/style-categories'
 import { getStaticData, useMainStore } from '@/lib/store'
 import type { CssProp, StyleProp } from '@/lib/theme'
 import { getThemeData, useCss } from '@/lib/theme'
@@ -276,22 +276,37 @@ export default function QuickViewOverlay() {
   }, [storeProductData])
 
   // Container tuck toggle gating: only render when this product is a
-  // container AND at least one child garment is tuckable. peekStyleCategoryIndex
-  // returns null before the index resolves (very early frames); the toggle
-  // just stays hidden until the child-category lookup can complete. Recomputes
-  // when the loaded product data changes.
-  const containerHasTuckableChild = useMemo(() => {
+  // container AND at least one child garment is tuckable. The category
+  // index is fetched async; a pure useMemo that reads
+  // peekStyleCategoryIndex() would latch to false forever if it ran
+  // before the fetch resolved (deps = [loadedProduct] only). Await the
+  // load in a useEffect and store the result — same pattern
+  // fitting-room-data's useResolvedFittingRoom uses.
+  const [containerHasTuckableChild, setContainerHasTuckableChild] = useState(false)
+  useEffect(() => {
     if (!loadedProduct?.container) {
-      return false
+      setContainerHasTuckableChild(false)
+      return
     }
-    const index = peekStyleCategoryIndex()
-    if (!index) {
-      return false
+    const container = loadedProduct.container
+    let cancelled = false
+    loadStyleCategoryIndex()
+      .then((index) => {
+        if (cancelled) {
+          return
+        }
+        const hasTuckable = container.children.some((c) => {
+          const cat = index.byName(String(c.style_category_name))
+          return !!cat?.tuckable
+        })
+        setContainerHasTuckableChild(hasTuckable)
+      })
+      .catch((error) => {
+        logger.logError('failed to load style category index for container tuck check', { error })
+      })
+    return () => {
+      cancelled = true
     }
-    return loadedProduct.container.children.some((c) => {
-      const cat = index.byName(String(c.style_category_name))
-      return !!cat?.tuckable
-    })
   }, [loadedProduct])
 
   const handleToggleContainerUntucked = useCallback(() => {

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -10,6 +10,17 @@ void i18n.use(initReactI18next).init({
     en: { translation: en },
     fr: { translation: fr },
   },
+  interpolation: {
+    // React already escapes children as text at render time — leaving
+    // i18next's default HTML-entity escaping on double-encodes any
+    // interpolated value that happens to contain '<', '>', '/', '&',
+    // '"' or "'". Manifested as e.g. "Recommended Size: S&#x2F;32" for
+    // container parent-size labels like "S/32". Turning i18next's
+    // escape off is safe because every consumer (LinkT, TextT,
+    // ButtonT) drops the translated string into a React children
+    // slot, not innerHTML.
+    escapeValue: false,
+  },
 })
 
 export { i18n, useTranslation }


### PR DESCRIPTION
Two bugs surfaced by container-parent styles on demo. Both in places that worked accidentally for single-garment styles.

## Double-encoded PDP recommended size

**Symptom:** \"Recommended Size: S&#x2F;32\" instead of \"S/32\".

**Cause:** [i18next default config](https://www.i18next.com/translation-function/interpolation#all-interpolation-options) escapes interpolated values as HTML entities. React already escapes children as text, so every interpolated value containing '/', '&', '<', '>', '\"' or \"'\" gets double-encoded. Container parent Sizes are merchant-defined free-form labels — slashes are typical (\"S/32\", \"M/34\", \"L/36\"). Single-garment size values like \"M\" or \"32\" never triggered this.

**Fix:** turn i18next escape off (\`interpolation.escapeValue = false\`) in \`src/lib/locale.ts\`. Safe because every consumer (\`LinkT\`, \`TextT\`, \`ButtonT\`) drops the translated string into React's \`{children}\` slot, not \`innerHTML\`; React handles the XSS escape.

## Container tuck toggle never appeared

**Symptom:** container product's PDP + fitting-room VTO had no tuck/untuck toggle, even when the container had a tuckable child (e.g. \"T-shirt + Pants\" set with an \`inner_tops\` child).

**Cause:** \`containerHasTuckableChild\` in [quick-view.tsx:283](https://github.com/TheFittingRoom/shop-sdk-ui/blob/main/src/components/overlays/quick-view.tsx#L283) was a \`useMemo\` over \`[loadedProduct]\` that called \`peekStyleCategoryIndex()\` synchronously. The style-category index is fetched async — if the memo ran before the fetch resolved (typical case, product data hits the store first), it latched to \`false\` and never recomputed when the index finally loaded.

**Fix:** mirror the \`useResolvedFittingRoom\` pattern ([fitting-room-data.ts:263](https://github.com/TheFittingRoom/shop-sdk-ui/blob/main/src/lib/fitting-room-data.ts#L263)) — \`useState\` + \`useEffect\` that awaits \`loadStyleCategoryIndex()\`, then computes and stores the flag. Recovers cleanly whichever order product-data and index-load finish in.

## Test plan

- [ ] \`npm run check\` clean (tsc + eslint + prettier).
- [ ] On a container product PDP with a tuckable child: recommended-size shows the label without entity codes, and a tuck/untuck toggle is visible. Toggling changes the rendered VTO.
- [ ] On a container product with NO tuckable children: no toggle appears (regression).
- [ ] On a single-garment product: no toggle (regression), size label unchanged.
- [ ] Cut a next release + promote to latest so demo picks up the fix.