### PR TITLE
Fitting-room canTuck: walk item.effective so container children participate

### DIFF
--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -149,22 +149,19 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
   // tuckable garment AND a non-tuckable garment layered above its tucked
   // position. A tuckable top with no bottom selected has nothing to tuck in
   // to, so every tuck control stays hidden.
-  const canTuck = useMemo<boolean>(
-    () =>
-      selectedItems.some((top) => {
-        const topCategory = top.styleCategory
-        if (!topCategory?.tuckable) {
-          return false
-        }
-        return selectedItems.some(
-          (other) =>
-            !!other.styleCategory &&
-            !other.styleCategory.tuckable &&
-            other.styleCategory.layer_order > topCategory.layer_order,
-        )
-      }),
-    [selectedItems],
-  )
+  //
+  // Walks item.effective, NOT item.styleCategory: for container products
+  // the top-level category is the container wrapper (e.g. suits_and_sets,
+  // tuckable=false), while item.effective expands to the container's
+  // child categories. Reading styleCategory.tuckable directly would miss
+  // a tuckable child inside a container — same anti-pattern isItemTuckable's
+  // comment warns against.
+  const canTuck = useMemo<boolean>(() => {
+    const allCategories = selectedItems.flatMap((item) => item.effective.map((e) => e.category))
+    return allCategories.some(
+      (top) => top.tuckable && allCategories.some((other) => !other.tuckable && other.layer_order > top.layer_order),
+    )
+  }, [selectedItems])
 
   // Availability map for every fitting-room item.
   const availabilityByExternalId = useMemo<Record<string, Availability>>(() => {


### PR DESCRIPTION
The tuck/untuck control (desktop pill + mobile per-item CTA) stayed hidden for any outfit containing a container product — even when the container had a tuckable child (e.g. a Set with a tuckable \`inner_tops\` child).

## Cause

[\`canTuck\` at index.tsx:154](https://github.com/TheFittingRoom/shop-sdk-ui/blob/main/src/components/overlays/fitting-room/index.tsx#L154) read \`top.styleCategory.tuckable\` directly. For containers, \`styleCategory\` is the **wrapper** (\`suits_and_sets\`, \`tuckable=false\`), not the child's category. This is exactly the anti-pattern the [\`isItemTuckable\` helper's comment warns against](https://github.com/TheFittingRoom/shop-sdk-ui/blob/main/src/lib/fitting-room-data.ts#L63-L67):

> Prefer this helper over reading \`item.styleCategory.tuckable\` directly — the latter is the PARENT category.

## Fix

Flatten every selected item's \`effective[].category\` and run the same \"tuckable-A layered under non-tuckable-B\" check on the flat list. For single-garment items \`effective[]\` contains only their own category, so behavior is unchanged. For containers it expands to each child's category, so a tuckable child correctly enables the toggle.

## Test plan

- [ ] Verified locally on a T-shirt+Pants container: pill (desktop) + per-item CTA (mobile) appear in the fitting-room; toggling flips \`containerUntucked\` which propagates uniformly to every tuckable child at wire-build (see \`makeOutfitItem\`).
- [ ] Regression: single-garment tuck-toggle behavior unchanged — same rule, applied to a single-element \`effective[]\`.
- [ ] Regression: outfit with only a tuckable top and nothing layered above stays with the toggle hidden (nothing to tuck INTO).
- [ ] \`npm run check\` clean.