### PR TITLE
Wire container tuck toggle into quick-view mobile layout

### DIFF
--- a/src/components/overlays/quick-view.tsx
+++ b/src/components/overlays/quick-view.tsx
@@ -592,9 +592,8 @@ function FittingRoomToggleButton() {
 // One toggle uniformly flips every tuckable child's `untucked` bool at
 // wire-build (see buildVtoWireItems). Non-container products never render
 // this button — quick-view has no outfit context for a single garment to
-// tuck into. TODO(container-tuck-mobile): mobile-layout equivalent —
-// the sub-content components (MobileContentCollapsed / Expanded / Full)
-// don't yet receive the tuck props from LayoutProps.
+// tuck into. Rendered by both DesktopLayout and MobileContentExpanded /
+// MobileContentFull; MobileContentCollapsed has no button container.
 function ContainerTuckToggleButton({ untucked, onToggle }: { untucked: boolean; onToggle: () => void }) {
   const css = useCss((theme) => ({
     button: {
@@ -664,6 +663,9 @@ function MobileLayout({
   onChangeSize,
   onAddToCart,
   onSignOut,
+  containerTuckable,
+  containerUntucked,
+  onToggleUntuck,
 }: LayoutProps) {
   const {
     snap: contentView,
@@ -818,6 +820,9 @@ function MobileLayout({
               onChangeSize={onChangeSize}
               onAddToCart={onAddToCart}
               onSignOut={onSignOut}
+              containerTuckable={containerTuckable}
+              containerUntucked={containerUntucked}
+              onToggleUntuck={onToggleUntuck}
             />
           </div>
         </div>
@@ -837,6 +842,13 @@ interface MobileContentProps {
   onChangeSize: (newSizeLabel: string) => void
   onAddToCart: () => void
   onSignOut: () => void
+  // Container tuck toggle — parallels DesktopLayout's props (see
+  // LayoutProps). MobileContentCollapsed has no button container and
+  // ignores these; Expanded and Full render <ContainerTuckToggleButton>
+  // beside the fitting-room CTA when containerTuckable is true.
+  containerTuckable: boolean
+  containerUntucked: boolean
+  onToggleUntuck: () => void
 }
 
 function MobileContentCollapsed({
@@ -891,6 +903,9 @@ function MobileContentExpanded({
   onChangeColor,
   onChangeSize,
   onAddToCart,
+  containerTuckable,
+  containerUntucked,
+  onToggleUntuck,
 }: MobileContentProps) {
   const css = useCss((_theme) => ({
     selectSizeLabelContainer: {
@@ -959,6 +974,9 @@ function MobileContentExpanded({
       <div css={css.buttonContainer}>
         <AddToCartButton onClick={onAddToCart} />
         <FittingRoomToggleButton />
+        {containerTuckable ? (
+          <ContainerTuckToggleButton untucked={containerUntucked} onToggle={onToggleUntuck} />
+        ) : null}
       </div>
       <div css={css.productDetailsContainer}>
         <LinkT
@@ -983,6 +1001,9 @@ function MobileContentFull({
   onChangeSize,
   onAddToCart,
   onSignOut,
+  containerTuckable,
+  containerUntucked,
+  onToggleUntuck,
 }: MobileContentProps) {
   const [fitChartOpen, setFitChartOpen] = useState<boolean>(false)
   const css = useCss((_theme) => ({
@@ -1093,6 +1114,9 @@ function MobileContentFull({
       <div css={css.buttonContainer}>
         <AddToCartButton onClick={onAddToCart} />
         <FittingRoomToggleButton />
+        {containerTuckable ? (
+          <ContainerTuckToggleButton untucked={containerUntucked} onToggle={onToggleUntuck} />
+        ) : null}
       </div>
       <div css={css.productDetailsContainer}>
         <LinkT


### PR DESCRIPTION
Closes the \`TODO(container-tuck-mobile)\` on \`ContainerTuckToggleButton\`. Desktop already rendered the toggle for container PDPs with a tuckable child; \`MobileLayout\` accepted the props on \`LayoutProps\` but didn't destructure them or forward to any of \`MobileContent{Collapsed, Expanded, Full}\`, so mobile shoppers had no way to toggle tuck.

## Wiring

- \`MobileLayout\`: destructure \`containerTuckable\` / \`containerUntucked\` / \`onToggleUntuck\` from \`LayoutProps\` and thread to \`<Content>\`.
- \`MobileContentProps\`: three new fields, typed identical to \`LayoutProps\`.
- \`MobileContentExpanded\` + \`MobileContentFull\`: render \`<ContainerTuckToggleButton>\` after \`<FittingRoomToggleButton>\` when \`containerTuckable\` is true, matching \`DesktopLayout\`'s placement.
- \`MobileContentCollapsed\` has no button container and legitimately skips the toggle.
- Updated \`ContainerTuckToggleButton\`'s docstring to reflect that both layouts render it now.

## Test plan

- [x] Verified locally on a container product with a tuckable \`inner_tops\` child at both Expanded and Full snap positions — toggle appears and flipping it drives the same \`containerUntucked\` state as desktop.
- [ ] Regression: single-garment product on mobile — no toggle (unchanged).
- [ ] Regression: container product with no tuckable children — no toggle (unchanged).
- [ ] \`npm run check\` clean.

## Companion

Pairs with shop-sdk-ui#80 (fitting-room \`canTuck\` walking \`item.effective\`). Together they close the container tuck-toggle gap across all four surfaces (quick-view desktop + mobile, fitting-room desktop + mobile).