### PR TITLE
Docs: clarify that `latest` promotion is optional for demo storefront

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ and renders a `<tfr-widget>` custom element.
   `npm run build` cleans + builds. CI runs `check` + `build`. ESLint ignores
   `src/api/gen/` (tygo-generated). Non-null assertions and `any` are errors;
   control statements must be braced; `react-hooks/exhaustive-deps` is a warning.
-- Consumers load the SDK via `<script type="module">` from a jsdelivr URL backed by the npm package `@thefittingroom/shop-ui`.
+- Consumers load the SDK via `<script type="module">` from a CDN URL backed by the npm package `@thefittingroom/shop-ui`. The `shopify` theme's `tfr.js` uses `unpkg.com/@thefittingroom/shop-ui@5` — a **semver range**, resolved by unpkg/jsdelivr to the highest matching published 5.x version regardless of dist-tag. **Consequence: publishing under `--tag next` is enough for the demo storefront to pick it up on the next reload; no `latest` promotion is required for that path.**
 
 ### Release flow
 
 Releases are explicit and human-initiated. No magic on PR merges. See
 README.md for the full walkthrough. Summary:
 
-1. **Cut a `next` release: trigger `.github/workflows/release.yaml`
+1. **Publish a release: trigger `.github/workflows/release.yaml`
    manually.** Actions tab → Release → Run workflow → pick patch /
    minor / major. The workflow does the entire release in one run:
    checks out main, builds (pre-bump verification), runs `npm version`,
@@ -29,12 +29,18 @@ README.md for the full walkthrough. Summary:
    main, and publishes to npm under dist-tag `next` via OIDC trusted
    publishing with `--provenance`. The npm trusted-publisher entry for
    `@thefittingroom/shop-ui` **must point at `release.yaml`**.
-2. **Promote `next` → `latest`** when ready for end users. Locally:
-   `git pull origin main && npm run promote-latest`. That runs
-   `npm dist-tag add ...@<ver> latest` — no new artifact, just re-points
-   the `latest` dist-tag at the already-published `next` build. The
-   runner needs to be `npm login`-ed with publish rights to
-   `@thefittingroom/shop-ui`. Override the version with
+
+   The published version is immediately live on the demo storefront —
+   `tfr.js`'s `unpkg.com/@thefittingroom/shop-ui@5` URL resolves to the
+   highest matching 5.x version regardless of dist-tag.
+
+2. **(Optional) Promote to `latest` dist-tag.** Only matters for
+   consumers who install without a version pin (`npm install
+   @thefittingroom/shop-ui`) or reference `@latest` in a CDN URL. The
+   demo storefront does not, so this step is not required for changes
+   to appear on demo. When you do want to move the `latest` pointer:
+   `git pull origin main && npm run promote-latest` locally (needs
+   `npm login` with publish rights). Override the version with
    `npm run promote-latest -- <version>`.
 
 The two-stage design (split bump from publish) was used previously to

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For an interactive debug loop, `npm run watch-serve &` in one terminal and
 Releases are explicit, human-initiated steps via a single GitHub Actions
 workflow. No magic on PR merges.
 
-**1. Cut a `next` release.**
+**1. Publish a release.**
 
 - Go to https://github.com/TheFittingRoom/shop-sdk-ui/actions/workflows/release.yaml
 - Click **Run workflow**
@@ -69,6 +69,13 @@ The `release.yaml` workflow does everything in one run:
 The npm trusted-publisher entry for `@thefittingroom/shop-ui` must
 point at `release.yaml`.
 
+**Demo storefront visibility:** the `shopify` theme's `tfr.js` loads
+the SDK from `unpkg.com/@thefittingroom/shop-ui@5` — a semver range
+that unpkg (and jsdelivr) resolves to the highest matching published
+5.x version regardless of dist-tag. Publishing under `--tag next` is
+therefore enough for demo to pick up the new version on the next
+reload; no `latest` promotion is required for that path.
+
 > **Branch protection note:** the workflow pushes commits + tags
 > directly to `main`. If you enable required-PR branch protection on
 > `main` later, this push will fail until either (a) the workflow uses
@@ -76,11 +83,13 @@ point at `release.yaml`.
 > branch protection allows the workflow to bypass via some other means.
 > The current setup deliberately defers that complication.
 
-**2. Promote `next` → `latest` when ready for end users.**
+**2. (Optional) Promote to `latest` dist-tag.**
 
-`release.yaml` only publishes under dist-tag `next`. To make a version
-the default that consumers get from `npm install @thefittingroom/shop-ui`,
-you have to explicitly promote it:
+Only matters for consumers who install without a version pin
+(`npm install @thefittingroom/shop-ui` → gets `latest`) or reference
+`@latest` in a CDN URL. The demo storefront does neither, so this
+step is not required for changes to appear on demo. When you do want
+to move the `latest` pointer:
 
 ```sh
 git pull origin main      # ensure package.json reflects the latest release


### PR DESCRIPTION
The prior release-flow docs (AGENTS.md + README.md) described a two-stage flow:

1. \"Cut a \`next\` release.\"
2. \"Promote \`next\` → \`latest\` when ready for end users.\"

Reading that as an outsider, step 2 sounds required — I assumed the demo storefront wouldn't see a change until the \`latest\` pointer moved.

## Reality

The \`shopify\` theme's [\`tfr.js\`](https://github.com/TheFittingRoom/shopify/blob/development/assets/tfr.js) loads the SDK from \`unpkg.com/@thefittingroom/shop-ui@5\` — a **semver range** URL that unpkg (and jsdelivr) resolves to the highest matching published 5.x version, regardless of dist-tag. So publishing under \`--tag next\` (what \`release.yaml\` does) is enough for demo to pick up the new version on the next reload.

The \`latest\` promotion only matters for consumers who:
- Install without a version pin (\`npm install ...\` → gets \`latest\`)
- Reference \`@latest\` in a CDN URL

Demo does neither.

## Changes

- \`AGENTS.md\`: added a bullet under the top overview noting the \`@5\` semver-range URL and its consequence; renamed step 1 \"Cut a \`next\` release\" → \"Publish a release\"; flagged step 2 as **(Optional) Promote to \`latest\` dist-tag** with the demo-visibility note inline.
- \`README.md\`: matching edits to the Release-process section.

Mechanics of both steps kept verbatim — the \`latest\` promotion path still works for anyone who needs to move the pointer.

## Test plan

- [x] Docs-only, no code changes.
- [x] `npm run check` unaffected.