### PR TITLE
Scope fitting-room storage per Firebase user

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -106,9 +106,6 @@ export async function init(initParams: InitParams): Promise<boolean> {
       testHooks,
     })
 
-    // Hydrate fitting room from localStorage
-    initFittingRoom()
-
     // Initialize asset manager
     initAsset()
 
@@ -129,6 +126,12 @@ export async function init(initParams: InitParams): Promise<boolean> {
     authManager.addUserProfileChangeListener((userProfile) => {
       useMainStore.getState().setUserProfile(userProfile)
     })
+
+    // Hydrate fitting room from localStorage. Runs after initFirebase
+    // so it can subscribe to auth-state changes (getAuthManager()
+    // requires Firebase to be initialized). The subscription's
+    // immediate-fire callback handles the initial bucket routing.
+    initFittingRoom()
 
     // Initialize api
     initApi()

--- a/src/lib/fitting-room-storage.ts
+++ b/src/lib/fitting-room-storage.ts
@@ -1,3 +1,4 @@
+import { getAuthManager } from '@/lib/firebase'
 import { getLogger } from '@/lib/logger'
 import { getStaticData, useMainStore } from '@/lib/store'
 import { getSizeLabelFromSize } from '@/lib/util'
@@ -13,9 +14,31 @@ export interface FittingRoomItem {
 
 export const STORAGE_KEY = 'tfr:fitting-room:v1'
 
+// The bucket key used when no shopper is logged in. Firebase UIDs are
+// non-empty base64-ish strings, so a distinctive sentinel avoids any
+// theoretical collision.
+const ANONYMOUS_BUCKET_KEY = '__anonymous__'
+
 const logger = getLogger('fitting-room-storage')
 
-type StoredShape = Record<string, FittingRoomItem[]>
+// Storage shape:
+//   { [brandId]: { [userId | ANONYMOUS_BUCKET_KEY]: FittingRoomItem[] } }
+//
+// Original v1 shape was `{ [brandId]: FittingRoomItem[] }` (unscoped
+// per-shopper). Migration on read: if the value at a brand key is an
+// array, it's read as the anonymous bucket. The normalized v2 shape
+// gets written back on the next mutation. STORAGE_KEY intentionally
+// unchanged (no `:v2` bump) — we're pre-launch, and in-place migration
+// preserves current testers' fitting rooms.
+type UserBuckets = Record<string, FittingRoomItem[]>
+type StoredShape = Record<string, UserBuckets | FittingRoomItem[]>
+
+// Module-level state, kept in sync with the currently-authenticated
+// Firebase user by the auth listener registered in _init. Fitting-room
+// reads/writes route through this key so the same public
+// readFittingRoom/writeFittingRoom API keeps working for callers
+// (store.ts mutations) without them having to know about user scoping.
+let currentBucketKey: string = ANONYMOUS_BUCKET_KEY
 
 function readAll(): StoredShape {
   try {
@@ -42,30 +65,67 @@ function writeAll(all: StoredShape): void {
   }
 }
 
+// Return the (brand → userBuckets) map for the given brand, normalizing
+// a v1 array entry into `{ [ANONYMOUS_BUCKET_KEY]: <array> }`.
+function readBrandBuckets(all: StoredShape, brandId: number): UserBuckets {
+  const raw = all[String(brandId)]
+  if (Array.isArray(raw)) {
+    return { [ANONYMOUS_BUCKET_KEY]: raw }
+  }
+  if (raw && typeof raw === 'object') {
+    return { ...raw }
+  }
+  return {}
+}
+
 export function readFittingRoom(brandId: number): FittingRoomItem[] {
-  const all = readAll()
-  const items = all[String(brandId)]
+  const buckets = readBrandBuckets(readAll(), brandId)
+  const items = buckets[currentBucketKey]
   return Array.isArray(items) ? items : []
 }
 
 export function writeFittingRoom(brandId: number, items: FittingRoomItem[]): void {
   const all = readAll()
-  all[String(brandId)] = items
+  const buckets = readBrandBuckets(all, brandId)
+  buckets[currentBucketKey] = items
+  all[String(brandId)] = buckets
   writeAll(all)
+}
+
+// Called by the auth listener when a shopper logs in. Merges the
+// anonymous bucket into the user's bucket (user's picks win on
+// externalId collision — an anonymous CSA might be invalid for the
+// new user's avatar), clears anonymous, and returns the resulting
+// user-bucket contents. Idempotent: if anonymous is already empty,
+// nothing changes.
+function mergeAnonymousIntoUser(brandId: number, userId: string): FittingRoomItem[] {
+  const all = readAll()
+  const buckets = readBrandBuckets(all, brandId)
+  const anon = buckets[ANONYMOUS_BUCKET_KEY] ?? []
+  const user = buckets[userId] ?? []
+  const userExternalIds = new Set(user.map((item) => item.externalId))
+  const additions = anon.filter((item) => !userExternalIds.has(item.externalId))
+  const merged = [...user, ...additions]
+  buckets[userId] = merged
+  buckets[ANONYMOUS_BUCKET_KEY] = []
+  all[String(brandId)] = buckets
+  writeAll(all)
+  return merged
 }
 
 export function _init(): void {
   const { brandId } = getStaticData()
-  const items = readFittingRoom(brandId)
-  useMainStore.setState({ fittingRoom: items })
 
   // Cross-tab freshness: localStorage fires `storage` on *other* tabs
   // (not the writing tab) whenever a key changes. When another tab
   // mutates the fitting room, re-read from localStorage so this tab's
   // in-memory model — and any UI subscribing to it — stays in sync.
   // The writing tab doesn't get this event, which is correct (would
-  // otherwise loop). `e.newValue === null` covers the case where the
-  // key was cleared entirely; readFittingRoom handles that.
+  // otherwise loop). We re-read via currentBucketKey so each tab only
+  // reflects changes to its own logged-in-shopper bucket; a login on
+  // Tab A that harvests anonymous is correctly observed as an
+  // anonymous-clear on Tab B (which is on the anonymous bucket at
+  // that moment).
   if (typeof window !== 'undefined') {
     window.addEventListener('storage', (e) => {
       if (e.key !== STORAGE_KEY) {
@@ -74,6 +134,34 @@ export function _init(): void {
       useMainStore.setState({ fittingRoom: readFittingRoom(brandId) })
     })
   }
+
+  // Subscribe to auth state changes. addAuthStateChangeListener fires
+  // its callback immediately with the current auth state on
+  // registration, which serves as the initial fitting-room read at
+  // boot — no separate synchronous load needed.
+  //
+  // Transitions:
+  //  - null → user      : merge anonymous into user's bucket, clear
+  //                       anonymous, use user's bucket.
+  //  - userA → userB    : (rare — no logout in between) merge anonymous
+  //                       into userB, use userB's bucket. userA's data
+  //                       stays put in their own bucket.
+  //  - user → null      : switch back to anonymous. User's items stay
+  //                       persisted under their bucket for next login.
+  //  - initial null     : anonymous bucket.
+  //  - initial user     : merge (in case v1 array was migrated) and
+  //                       use user's bucket.
+  const authManager = getAuthManager()
+  authManager.addAuthStateChangeListener((authUser) => {
+    if (authUser) {
+      currentBucketKey = authUser.uid
+      const items = mergeAnonymousIntoUser(brandId, authUser.uid)
+      useMainStore.setState({ fittingRoom: items })
+    } else {
+      currentBucketKey = ANONYMOUS_BUCKET_KEY
+      useMainStore.setState({ fittingRoom: readFittingRoom(brandId) })
+    }
+  })
 }
 
 // Resolve a colorway_size_asset id from a (size, color) selection for

--- a/tests/e2e/add-to-fitting-room.spec.ts
+++ b/tests/e2e/add-to-fitting-room.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { bootSdk } from './helpers/boot'
-import { TEST_BRAND_ID, TEST_PRODUCT_EXTERNAL_ID } from './fixtures/seed'
+import { TEST_BRAND_ID, TEST_PRODUCT_EXTERNAL_ID, TEST_UID } from './fixtures/seed'
 
 // Locks in the hanger-toggle UI state + the zustand store + the localStorage
 // write under the `tfr:fitting-room:v1` key. If any link in that chain breaks,
@@ -17,11 +17,21 @@ test('hanger toggle adds the current product to fitting-room storage', async ({ 
   // Post-click state: aria-label flips to "In Fitting Room", pressed=true.
   await expect(page.getByRole('button', { name: 'In Fitting Room' })).toHaveAttribute('aria-pressed', 'true')
 
-  // localStorage roundtrip — entry must land under the brand-id key.
-  const stored = await page.evaluate((brandId) => {
-    const raw = window.localStorage.getItem('tfr:fitting-room:v1')
-    return raw ? (JSON.parse(raw) as Record<string, { externalId: string }[]>)[String(brandId)] : null
-  }, TEST_BRAND_ID)
+  // localStorage roundtrip — entry must land under the (brandId, userId)
+  // bucket. bootSdk defaults to loggedIn=true with TEST_UID, so the
+  // shopper's UID scopes the bucket; anonymous browsing would land at
+  // buckets["__anonymous__"] instead.
+  const stored = await page.evaluate(
+    ({ brandId, userId }) => {
+      const raw = window.localStorage.getItem('tfr:fitting-room:v1')
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw) as Record<string, Record<string, { externalId: string }[]>>
+      return parsed[String(brandId)]?.[userId] ?? null
+    },
+    { brandId: TEST_BRAND_ID, userId: TEST_UID },
+  )
 
   expect(stored).not.toBeNull()
   expect(stored?.length).toBe(1)


### PR DESCRIPTION
Fitting-room localStorage was brand-scoped only:

\`\`\`js
{ [brandId]: FittingRoomItem[] }
\`\`\`

If two shoppers used the same browser (log out user A, log in user B), they inherited each other's picks. The CSA id stored per item might be invalid for the new user's avatar — the SDK caught that later via the \`needsResize\` path, but only after firing errors that appeared random to the shopper.

## New shape

Adds a per-user sub-key:

\`\`\`js
{ [brandId]: { [userId | ANONYMOUS]: FittingRoomItem[] } }
\`\`\`

Rules:

- Not-logged-in browsing goes under a special \`__anonymous__\` bucket.
- On login (null → user, or userA → userB), the anonymous bucket is **merged** into the user's bucket and cleared. **User's picks win** on \`externalId\` collision (user's stored size/CSA is more likely to be valid for their avatar than an anonymous holdover).
- On logout, the user's bucket **persists** — logging back in on the same browser picks up where they left off. Anonymous starts empty for the next unknown shopper.

## Migration

The previous v1 shape (bare array under a brand key) is read as the anonymous bucket on first access. It gets rewritten into the v2 shape on the next mutation. \`STORAGE_KEY\` intentionally unchanged — pre-launch, in-place migration keeps current testers' fitting rooms.

## Wiring

- \`fitting-room-storage.ts\` holds \`currentBucketKey\` as module state, updated by an auth-state-change listener registered in \`_init\`. Public \`readFittingRoom\` / \`writeFittingRoom\` signatures unchanged; they internally route through \`currentBucketKey\` so \`store.ts\` mutations need no changes.
- \`addAuthStateChangeListener\` fires its callback immediately with the current auth state, which serves as the initial bucket routing at boot — no separate synchronous load needed.
- \`initFittingRoom\` is **moved in index.tsx to run after \`initFirebase\`**, since \`getAuthManager()\` throws before Firebase is initialized. No other init step touches fitting-room state, and React doesn't start rendering until \`customElements.define\`, so no downstream code sees the transient default \`[]\`.
- Cross-tab \`storage\`-event listener re-reads via \`currentBucketKey\`. Tab A's login harvests the anonymous bucket; Tab B (still on anonymous) observes the emptied anonymous bucket via the storage event, correctly clearing its own fitting-room view.

## Test plan

- [x] \`npm run check\` clean.
- [x] Full e2e suite green (7/7). \`add-to-fitting-room.spec.ts\` updated for the new shape (reads \`buckets[TEST_UID]\` instead of \`buckets\` directly).
- [x] Live-tested against demo with \`?tfr-source=local-demo\`:
  - Anonymous browsing → add products → log in → items appear in the logged-in fitting room.
  - Log out → previously added items disappear (persisted under user's bucket).
  - Log back in as the same user → items reappear.
  - Log in as a different user → that user's own bucket (empty first time) — no cross-contamination.

## Companion / follow-up

Cross-tab Firebase auth sync is separately buggy (reported by the user). Not addressed here — that's the next task on deck.