### PR TITLE
CI: rename PR workflow to make it clear it runs tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: Build Dev
+name: PR Checks
 
 on:
   pull_request:
@@ -7,7 +7,11 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build_dev:
+  verify:
+    # Job name intentionally short — this is the required-status-check
+    # context that shows next to the merge button on every PR. Renaming
+    # here means updating the repository ruleset's
+    # required_status_checks contexts too (Settings → Rules → main).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,10 +25,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: 'npm'
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Check (tsc + lint)
+      - name: Type-check + lint + format-check
         run: npm run check
 
       - name: Build


### PR DESCRIPTION
Phase 1 of two. Renames the PR-verification workflow so the required-check name (which will appear next to the merge button on every PR after phase 2) accurately describes what runs.

## Changes

- \`.github/workflows/build.yml\` → \`.github/workflows/pr-checks.yml\`
- Workflow name: \`Build Dev\` → \`PR Checks\`
- Job: \`build_dev\` → \`verify\`
- Step: \`Check (tsc + lint)\` → \`Type-check + lint + format-check\` (\`npm run check\` runs prettier too now)

No pipeline behavior changes — same install / check / build / e2e steps, same Playwright report upload on failure.

## Why

The old \`Build Dev\` name misrepresented what the workflow does (it's not a deploy, it runs PR verification including e2e tests). New name aligns with what shopper-side reviewers see.

## Phase 2 (after this merges)

Add a repository ruleset targeting \`main\` that:
- Requires a PR to merge (blocks direct pushes from humans).
- Requires the \`verify\` context to be green before merge.
- Adds \`github-actions[bot]\` to the bypass list so \`release.yaml\`'s \`git push origin main --follow-tags\` continues working (keeps the one-button release flow).

Configured via \`gh api\`, not a workflow file. I'll set that up right after this merges so the ruleset can immediately require \`verify\` (which is only defined on main once this PR lands).

## Test plan

- [x] Workflow file renders cleanly on the Actions tab after push.
- [ ] This PR's own \`verify\` check runs and passes (proves the rename didn't break anything).
- [ ] Post-merge: phase 2 ruleset applied. Follow-up PR opened just to verify the merge button correctly reports the required check.