### PR TITLE
CI: automate release via PR + auto-merge, gate main on verify

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened]
+  # release.yaml pushes a release-bump-<timestamp> branch, then opens a
+  # PR via GITHUB_TOKEN. PRs opened by GITHUB_TOKEN don't trigger new
+  # workflow runs (GitHub anti-loop rule), so `pull_request` above
+  # wouldn't fire — and the `verify` required-check would never post,
+  # blocking auto-merge forever. Trigger on branch push instead: fires
+  # a `verify` check-run against the pushed SHA, which the PR's
+  # required-check picks up when it's opened moments later.
+  push:
+    branches:
+      - 'release-bump-*'
 
 jobs:
   verify:
@@ -12,11 +22,31 @@ jobs:
     # context that shows next to the merge button on every PR. Renaming
     # here means updating the repository ruleset's
     # required_status_checks contexts too (Settings → Rules → main).
+    #
+    # Skip the actual verification steps for release-bump-* branches:
+    # release.yaml's bump commit only touches package.json /
+    # package-lock.json / dist rebuild — nothing that can fail lint,
+    # tsc, or tests differently from the pre-bump verify that
+    # release.yaml already ran. Job-level `if: false` produces a
+    # `skipped` check-run, which GitHub counts as SUCCESS for
+    # required-status-checks (workflow-level skips via `paths-ignore`
+    # produce no check-run at all and would block indefinitely).
+    if: >-
+      !(
+        (github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release-bump-')) ||
+        (github.event_name == 'push' && startsWith(github.ref_name, 'release-bump-'))
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          # For pull_request: check out the PR head (not the synthetic
+          # merge commit) so lint/tsc/tests run against exactly what
+          # the branch contains.
+          # For push (branch-push case, only reached when the branch
+          # isn't a release-bump-* — see the if above), default checkout
+          # of github.sha is correct.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,19 @@ name: Release
 # tied to PATs, `pull_request_target` quirks, and OIDC trigger
 # restrictions).
 #
-# This workflow does the entire release in one run: bump → tag → push →
-# npm publish via OIDC trusted publishing. No long-lived secrets needed.
-# The npm trusted-publisher entry for @thefittingroom/shop-ui must
-# point at this file (release.yaml).
+# Flow: build (pre-bump verify) → bump on a fresh release-bump-<ts>
+# branch → publish to npm via OIDC trusted publishing → open PR to main
+# → enable auto-merge. GitHub Actions completes; auto-merge fires
+# moments later once pr-checks posts the (skipped) verify check-run on
+# the bump SHA. The main branch's `pull_request` + `required_status_checks`
+# ruleset stays satisfied because the check-run posts even though the
+# job body is skipped for release-bump-* branches (see pr-checks.yml
+# job-level `if:`).
+#
+# No long-lived secrets: GITHUB_TOKEN handles the branch push, PR
+# creation, and auto-merge queueing; npm publish uses OIDC trusted
+# publishing. The npm trusted-publisher entry for @thefittingroom/shop-ui
+# must point at this file (release.yaml).
 #
 # To release:
 #   Actions tab → Release → Run workflow → pick patch/minor/major → Run.
@@ -30,9 +39,10 @@ permissions:
   # Required for OIDC trusted publishing — lets the runner mint a
   # short-lived token npm exchanges for publish rights.
   id-token: write
-  # Required for the workflow to push the bumped package.json + tag
-  # back to main.
+  # Required to push the release-bump branch + tag.
   contents: write
+  # Required to open the auto-merge PR against main.
+  pull-requests: write
 
 jobs:
   release:
@@ -55,7 +65,7 @@ jobs:
         run: npm ci
 
       # Verify the build succeeds before bumping/tagging — fail fast if
-      # something is broken on main rather than after pushing a tag.
+      # something is broken on main rather than after publishing to npm.
       - name: Build (pre-bump verification)
         run: npm run build
 
@@ -64,9 +74,19 @@ jobs:
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 
-      # Bumps package.json and creates a vX.Y.Z tag locally. The bump
-      # commit's parent is whatever main currently points at, so subsequent
-      # releases see the new version on next checkout.
+      # Create a fresh branch for the bump. We push the bump here (not
+      # to main) so the main-branch ruleset's pull_request requirement
+      # isn't violated by a direct push. The PR-based merge path
+      # requires this indirection.
+      - name: Create release-bump branch
+        id: bump_branch
+        run: |
+          BUMP_BRANCH="release-bump-$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$BUMP_BRANCH"
+          echo "name=$BUMP_BRANCH" >> "$GITHUB_OUTPUT"
+
+      # Bumps package.json + package-lock.json, creates a bump commit,
+      # and creates a vX.Y.Z tag locally on that commit.
       - name: Bump version
         run: npm version "${{ inputs.version_bump }}"
 
@@ -76,15 +96,49 @@ jobs:
       - name: Build (post-bump)
         run: npm run build
 
-      # Pushes both the bump commit and the new tag back to main. Branch
-      # protection isn't enabled on main yet; if you turn it on, this
-      # step will need a credential with bypass rights (see AGENTS.md
-      # release section for the discussion).
-      - name: Push commit + tag
-        run: git push origin main --follow-tags
+      # Push the bump branch + the vX.Y.Z tag. Pushing the branch
+      # triggers pr-checks.yml on `push` — its verify job is
+      # `if:`-skipped for release-bump-* branches, producing a skipped
+      # (success) check-run on the bump SHA. Main's required-status-check
+      # sees that as passing, unblocking auto-merge below.
+      #
+      # Tag stays on the bump commit even after the branch is squash-
+      # merged + deleted — tag refs are independent of branch refs. `git
+      # log v5.0.39` continues to work; the tag just doesn't reach main
+      # by parent traversal.
+      - name: Push bump branch + tag
+        run: git push origin "${{ steps.bump_branch.outputs.name }}" --follow-tags
 
       # OIDC trusted publishing — no NPM_TOKEN. --provenance attaches a
       # supply-chain attestation tying this tarball to this workflow run
       # and the just-pushed commit.
       - name: Publish to npm (next)
         run: npm publish --tag next --provenance --verbose
+
+      # Open the PR + queue auto-merge. GitHub finishes the merge once
+      # pr-checks.yml's `verify` check posts (which happens within
+      # seconds of the branch push above — job is `if:`-skipped for
+      # release-bump-* branches). Workflow exits before the merge
+      # completes; check the PR in the Actions/PRs tab for the final
+      # merge event.
+      - name: Open + auto-merge release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_BRANCH: ${{ steps.bump_branch.outputs.name }}
+        run: |
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          gh pr create \
+            --base main \
+            --head "$BUMP_BRANCH" \
+            --title "chore: release v${NEW_VERSION}" \
+            --body "$(cat <<EOF
+          Automated release-bump PR opened by \`release.yaml\`.
+
+          - Bump: \`${{ inputs.version_bump }}\` → \`v${NEW_VERSION}\`
+          - Published to npm as \`v${NEW_VERSION}\` under dist-tag \`next\`
+          - Tag \`v${NEW_VERSION}\` already pushed to the bump commit
+
+          The \`verify\` required-check is skipped for \`release-bump-*\` branches (see \`pr-checks.yml\` job-level \`if:\`) — the actual verification ran pre-bump in \`release.yaml\`. Auto-merge will fire as soon as GitHub records the skipped check.
+          EOF
+          )"
+          gh pr merge "$BUMP_BRANCH" --squash --auto --delete-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,16 +23,21 @@ README.md for the full walkthrough. Summary:
 
 1. **Publish a release: trigger `.github/workflows/release.yaml`
    manually.** Actions tab → Release → Run workflow → pick patch /
-   minor / major. The workflow does the entire release in one run:
-   checks out main, builds (pre-bump verification), runs `npm version`,
-   rebuilds with the new version, pushes the bump commit + tag back to
-   main, and publishes to npm under dist-tag `next` via OIDC trusted
-   publishing with `--provenance`. The npm trusted-publisher entry for
-   `@thefittingroom/shop-ui` **must point at `release.yaml`**.
+   minor / major. The workflow: checks out main, builds (pre-bump
+   verification), runs `npm version` on a fresh `release-bump-<ts>`
+   branch, rebuilds with the new version, pushes the branch + tag,
+   publishes to npm under dist-tag `next` via OIDC trusted publishing
+   with `--provenance`, then opens an auto-merge PR to main. GitHub
+   completes the squash-merge seconds later once `pr-checks.yml`
+   posts the (skipped) `verify` check-run on the bump SHA. The npm
+   trusted-publisher entry for `@thefittingroom/shop-ui` **must
+   point at `release.yaml`**.
 
    The published version is immediately live on the demo storefront —
    `tfr.js`'s `unpkg.com/@thefittingroom/shop-ui@5` URL resolves to the
-   highest matching 5.x version regardless of dist-tag.
+   highest matching 5.x version regardless of dist-tag. Demo picks up
+   the new version even before the auto-merge PR completes (npm
+   publish and GitHub merge are independent).
 
 2. **(Optional) Promote to `latest` dist-tag.** Only matters for
    consumers who install without a version pin (`npm install
@@ -52,23 +57,36 @@ chain. Historical context preserved here in case the constraint comes
 back or someone needs to re-derive why we don't auto-publish on PR
 merge.
 
-#### Branch protection caveat
+#### Ruleset + auto-merge coupling
 
-`release.yaml` pushes the bump commit + tag directly to `main` using
-the workflow's auto-issued `GITHUB_TOKEN`. This works because main has
-no required-PR branch protection rule. If branch protection is added
-later, that push will fail (`GITHUB_TOKEN` is not in any bypass list
-by default). At that point you have three options:
+`main` is protected by a repository ruleset (Settings → Rules) that
+requires PRs to merge AND requires the `verify` context to be green.
+`release.yaml` can't `git push origin main` directly under that
+ruleset (`GITHUB_TOKEN`-authenticated pushes aren't in any bypass
+list — repo-scoped rulesets can't reference the GitHub Actions
+integration as a bypass actor). Instead:
 
-- Use a fine-grained PAT or GitHub App listed in the branch-protection
-  bypass settings; `actions/checkout` is configured with its token
-  via `with: token: ${{ secrets.... }}`
-- Have the workflow open a PR with the bump rather than push directly,
-  and hand-merge it (this defeats the "one button" simplicity)
-- Don't enable required-PR protection on main (current state)
+- Push the bump on a `release-bump-<ts>` branch (not main).
+- Push triggers `pr-checks.yml` on the branch — the `verify` job
+  is `if:`-skipped for `release-bump-*` branches, producing a
+  skipped (success) check-run on the bump SHA. Job-level skip
+  posts a check-run; workflow-level `paths-ignore` would post
+  none, blocking indefinitely.
+- Open the PR via `gh pr create` + queue auto-merge via
+  `gh pr merge --auto`. GitHub finishes the squash-merge as soon
+  as the required-check is recorded.
 
-The simplification of the single-workflow design depends on direct
-push being allowed; the choice is real.
+The `verify` skip is safe: the release bump only touches
+`package.json` + `package-lock.json` + a `dist/` rebuild whose only
+difference is the embedded version string — nothing that lint, tsc,
+or tests would fail on differently than the pre-bump verify that
+`release.yaml` already ran.
+
+If the org later grants the repo the ability to reference the
+GitHub Actions integration as a bypass actor at ruleset creation
+time (org-level ruleset, or via an app installation), the flow can
+revert to a direct-push design — see the git history for how
+`release.yaml` looked before the auto-merge PR indirection landed.
 
 #### Why no auto-publish on PR merge
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,16 @@ workflow. No magic on PR merges.
 The `release.yaml` workflow does everything in one run:
 
 1. Checks out `main`, installs deps, builds (verifies it compiles)
-2. Runs `npm version <bump>` — bumps `package.json` and creates the
-   `vX.Y.Z` tag
-3. Rebuilds with the new version embedded
-4. Pushes the bump commit + tag back to `main`
-5. Publishes to npm under dist-tag `next` via
+2. Creates a fresh `release-bump-<timestamp>` branch
+3. Runs `npm version <bump>` — bumps `package.json`, creates the
+   bump commit, tags it `vX.Y.Z`
+4. Rebuilds with the new version embedded
+5. Pushes the bump branch + tag (not to `main` — see below)
+6. Publishes to npm under dist-tag `next` via
    [npm trusted publishing](https://docs.npmjs.com/trusted-publishers)
    (OIDC, no long-lived secret) with `--provenance` for supply-chain
    attestation
+7. Opens a PR from the bump branch to `main` and queues auto-merge
 
 The npm trusted-publisher entry for `@thefittingroom/shop-ui` must
 point at `release.yaml`.
@@ -74,14 +76,20 @@ the SDK from `unpkg.com/@thefittingroom/shop-ui@5` — a semver range
 that unpkg (and jsdelivr) resolves to the highest matching published
 5.x version regardless of dist-tag. Publishing under `--tag next` is
 therefore enough for demo to pick up the new version on the next
-reload; no `latest` promotion is required for that path.
+reload; no `latest` promotion is required for that path. Demo picks
+up the new version even before the auto-merge PR completes — npm
+publish and GitHub merge are independent steps.
 
-> **Branch protection note:** the workflow pushes commits + tags
-> directly to `main`. If you enable required-PR branch protection on
-> `main` later, this push will fail until either (a) the workflow uses
-> a credential listed in the branch-protection bypass list, or (b)
-> branch protection allows the workflow to bypass via some other means.
-> The current setup deliberately defers that complication.
+> **Ruleset + auto-merge note:** `main` is protected by a repository
+> ruleset requiring PRs + a passing `verify` check. `release.yaml`
+> works around this by pushing to a `release-bump-*` branch and
+> opening an auto-merge PR. The `verify` job in `pr-checks.yml` is
+> `if:`-skipped for `release-bump-*` branches (safe — the bump only
+> touches `package.json` + `package-lock.json` + a `dist/` rebuild
+> whose only diff is the embedded version), so the required-check
+> reports success immediately and auto-merge fires within seconds
+> of the branch push. See `AGENTS.md` → "Ruleset + auto-merge
+> coupling" for the full rationale.
 
 **2. (Optional) Promote to `latest` dist-tag.**
 


### PR DESCRIPTION
Phase 2 of the CI cleanup. Enables required-status-checks on \`main\` without breaking the one-button release flow. Two coordinated file changes; ruleset creation is a follow-up \`gh api\` call.

## What breaks without this coordination

The obvious plan is \"enable \`required_status_checks\` on main\" — but \`release.yaml\` currently does \`git push origin main --follow-tags\`, and \`GITHUB_TOKEN\`-authenticated pushes can't be added to a bypass list at the repo ruleset level (the GitHub Actions integration must be part of the ruleset source or owner organization, and org-level scope needs \`admin:org\`). So enabling the rule with the current \`release.yaml\` immediately breaks releases.

## What this does instead

### \`pr-checks.yml\`

Adds a \`push\` trigger for \`release-bump-*\` branches so \`verify\` can post a check-run on the bump SHA even when \`release.yaml\` opens the PR via \`GITHUB_TOKEN\` (which normally suppresses downstream workflow runs).

Job-level \`if:\` **skips** the actual verification steps for release-bump-* branches. GitHub reports skipped jobs with a check-run conclusion of \`skipped\`, which counts as SUCCESS for required-status-checks (workflow-level skips via \`paths-ignore\` would post no check-run at all and block indefinitely).

Skipping is safe: the release bump only touches \`package.json\`, \`package-lock.json\`, and a \`dist/\` rebuild whose only diff is the embedded version string. Nothing that lint / tsc / tests would fail on differently than the pre-bump verify that \`release.yaml\` already runs.

### \`release.yaml\`

Instead of \`git push origin main --follow-tags\`, the workflow now:

1. Creates a \`release-bump-<utc-timestamp>\` branch.
2. Runs \`npm version <bump>\` on it (bumps + tags).
3. Pushes branch + tag (triggers \`pr-checks\` push-event run).
4. Publishes to npm.
5. \`gh pr create\` → \`gh pr merge --auto --squash --delete-branch\`.

Workflow exits before the merge. GitHub finishes the squash-merge within seconds of \`pr-checks\` posting the (skipped) \`verify\` check.

Adds \`pull-requests: write\` to \`permissions:\`.

Tag stays reachable on the (now orphaned post-squash) bump commit — \`git log v5.0.39\` continues to work; the tag just doesn't reach main by parent traversal.

### Docs

\`AGENTS.md\` release section + branch-protection subsection rewritten to describe the ruleset + auto-merge coupling. \`README.md\` release-process section matches.

## Follow-up (after merge)

Create the active ruleset via:

\`\`\`sh
gh api repos/TheFittingRoom/shop-sdk-ui/rulesets --method POST --input <json>
\`\`\`

with:

- \`enforcement: active\`
- \`rules\`: \`pull_request\`, \`required_status_checks\` (context: \`verify\`), \`non_fast_forward\`
- \`bypass_actors: []\` (bot doesn't need bypass — the auto-merge PR path handles it)

The existing evaluate-mode ruleset gets deleted first, then replaced with the active version.

## Test plan

- [x] \`npm run check\` clean.
- [ ] This PR's own \`verify\` runs and passes (proves the \`if:\` correctly identifies non-bump PRs as \"run normally\").
- [ ] Post-merge: I create the active ruleset, then trigger a patch release via workflow_dispatch as a live test. Expected: bump branch pushed, npm publishes, PR opens, auto-merge fires within seconds, main gets a squash commit, bump branch deleted.

## Bundled in one PR per your preference

Bundling the pr-checks + release.yaml + docs changes — they only make sense together (release.yaml's new PR path depends on pr-checks' skip guard; docs must match the code).