### PR TITLE
CI: auto-approve the release PR's pr-checks run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ permissions:
   contents: write
   # Required to open the auto-merge PR against main.
   pull-requests: write
+  # Required to approve the downstream pr-checks workflow run that
+  # GitHub gates with `action_required` when a bot opens the PR.
+  actions: write
 
 jobs:
   release:
@@ -117,8 +120,8 @@ jobs:
 
       # Open the PR + queue auto-merge. GitHub finishes the merge once
       # pr-checks.yml's `verify` check posts (which happens within
-      # seconds of the branch push above — job is `if:`-skipped for
-      # release-bump-* branches). Workflow exits before the merge
+      # seconds of the auto-approve step below — job is `if:`-skipped
+      # for release-bump-* branches). Workflow exits before the merge
       # completes; check the PR in the Actions/PRs tab for the final
       # merge event.
       - name: Open + auto-merge release PR
@@ -142,3 +145,41 @@ jobs:
           EOF
           )"
           gh pr merge "$BUMP_BRANCH" --squash --auto --delete-branch
+
+      # Auto-approve the pr-checks workflow run triggered by the PR
+      # above. Any `pull_request` event on a PR opened by GITHUB_TOKEN
+      # gets `action_required` (GitHub's anti-loop guard for
+      # bot-triggered workflows — not configurable at the repo level).
+      # Without this, the pr-checks run sits waiting for a human, the
+      # `verify` check-run never posts, and auto-merge never fires.
+      #
+      # Approving a workflow run is separate from the anti-loop rule
+      # and IS allowed for GITHUB_TOKEN with `actions: write`. Once
+      # approved, the run executes: the `verify` job hits its `if:`
+      # guard, skips, and posts a `skipped` check-run — success for
+      # required-status-checks — and auto-merge fires seconds later.
+      #
+      # Poll for up to ~60s in case the pull_request event hasn't
+      # created the run yet (typically appears within 1–2s).
+      - name: Auto-approve the pr-checks run for the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_BRANCH: ${{ steps.bump_branch.outputs.name }}
+        run: |
+          for attempt in $(seq 1 30); do
+            RUN_ID=$(gh run list \
+              --workflow=pr-checks.yml \
+              --branch="$BUMP_BRANCH" \
+              --limit=1 \
+              --json databaseId,conclusion,status \
+              --jq '.[] | select(.conclusion == "action_required") | .databaseId')
+            if [ -n "$RUN_ID" ]; then
+              echo "Approving pr-checks run $RUN_ID"
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/approve" --method POST
+              exit 0
+            fi
+            echo "Attempt $attempt: no action_required pr-checks run yet, waiting…"
+            sleep 2
+          done
+          echo "::warning::No action_required pr-checks run appeared within timeout. PR will need manual approval." >&2
+          exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,14 +67,23 @@ list — repo-scoped rulesets can't reference the GitHub Actions
 integration as a bypass actor). Instead:
 
 - Push the bump on a `release-bump-<ts>` branch (not main).
-- Push triggers `pr-checks.yml` on the branch — the `verify` job
-  is `if:`-skipped for `release-bump-*` branches, producing a
-  skipped (success) check-run on the bump SHA. Job-level skip
-  posts a check-run; workflow-level `paths-ignore` would post
-  none, blocking indefinitely.
 - Open the PR via `gh pr create` + queue auto-merge via
   `gh pr merge --auto`. GitHub finishes the squash-merge as soon
   as the required-check is recorded.
+- `pull_request` events fired by a PR opened via GITHUB_TOKEN get
+  `action_required` — GitHub's anti-loop guard for bot-triggered
+  workflows, not configurable at the repo level. Without an
+  override, the `verify` check-run never posts and auto-merge
+  blocks forever.
+- `release.yaml`'s final step polls for that action_required run
+  and approves it via `POST /actions/runs/{id}/approve` (needs
+  `actions: write`). Approval is a separate authorization from the
+  anti-loop rule and is allowed for GITHUB_TOKEN.
+- Once approved, the `verify` job hits its `if:` guard, skips, and
+  posts a `skipped` check-run. Job-level skip posts a check-run;
+  workflow-level `paths-ignore` would post none, blocking
+  indefinitely. `skipped` counts as SUCCESS for
+  required-status-checks, and auto-merge fires.
 
 The `verify` skip is safe: the release bump only touches
 `package.json` + `package-lock.json` + a `dist/` rebuild whose only


### PR DESCRIPTION
Follow-up to #85. Closes the last remaining manual step in the automated release flow.

## What I found in the live test

Triggered a patch release (v5.0.38 → v5.0.39) right after #85 merged + the active ruleset was applied. The workflow ran clean: bump branch pushed, npm published, PR #86 opened, auto-merge queued.

Then it stalled. The \`verify\` check never posted, so required-status-checks blocked auto-merge indefinitely.

**Root cause:** the \`pull_request\` event from a PR opened via \`GITHUB_TOKEN\` gets \`action_required\` (GitHub's anti-loop guard for bot-triggered workflows — [documented here](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). Not configurable at the repo level; also not the same as the \"first-time contributor approval\" setting.

I manually approved the pending run via \`gh api ...\`. The rest of the chain worked exactly as designed — the \`verify\` job hit its \`if:\` guard, skipped, posted a \`skipped\` check-run (which counts as SUCCESS), auto-merge fired, PR #86 merged.

## Fix

Add an auto-approve step at the end of \`release.yaml\`. Poll for up to ~60s for the \`action_required\` run on the bump branch, then call \`POST /actions/runs/{id}/approve\`. Approval is a **separate** authorization from the anti-loop rule and IS allowed for GITHUB_TOKEN with \`actions: write\` (added to \`permissions:\`).

## Timeline for a release, post-merge

- t=0 : \`release.yaml\` starts
- t=~10s : bump branch pushed
- t=~15s : npm publish completes
- t=~17s : \`gh pr create\` + \`gh pr merge --auto\`
- t=~19s : approve step finds the \`action_required\` run, approves it
- t=~25s : verify job skips, posts check-run
- t=~30s : auto-merge fires, main updated

## Test plan

- [x] \`npm run check\` clean.
- [ ] After merging this PR, trigger another patch release (v5.0.39 → v5.0.40). Expected: no manual approval needed, PR opens and auto-merges within ~30s of the release workflow completing.