### PR TITLE
Debounce transient auth nulls from Firebase cross-tab sync

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -131,6 +131,25 @@ export function getFirestoreManager(): IFirestoreManager {
   return firestoreManager
 }
 
+// Firebase's cross-tab auth sync (browserLocalPersistence + IndexedDB)
+// can fire a transient `null` on an already-loaded tab when a second tab
+// initializes Firebase — an IndexedDB lock/read race that resolves
+// within tens to hundreds of ms once Firebase re-reads and re-fires the
+// real user. Left unswallowed, the SDK briefly flips the store to
+// "logged out" and the UI kicks the shopper out.
+//
+// Debounce null dispatches to subscribers: schedule a null propagation
+// this many ms after Firebase fires null. If a user event (typically
+// Firebase's own recovery) arrives before the timer fires, cancel it.
+// If the timer does fire, re-check auth.currentUser first — Firebase
+// may have recovered without firing a distinct user event.
+//
+// 500 ms is well above the observed cross-tab recovery window (<100 ms
+// in practice) and low enough that explicit user-initiated signOut
+// still feels responsive (shopper just clicked "sign out"; a half-second
+// pause is fine).
+const CROSS_TAB_NULL_DEBOUNCE_MS = 500
+
 export class AuthManager implements IAuthManager {
   private readonly auth: Auth
   private readonly brandId: number
@@ -138,14 +157,41 @@ export class AuthManager implements IAuthManager {
   private readonly authStateChangeListeners: Set<(authUser: AuthUser | null) => void> = new Set()
   private readonly userProfileChangeListeners: Set<(userProfile: UserProfile | null) => void> = new Set()
   private listenToUserProfileUnsub: Unsubscribe | null = null
+  private pendingNullDispatchTimeout: ReturnType<typeof setTimeout> | null = null
 
   constructor(auth: Auth, brandId: number) {
     this.auth = auth
     this.brandId = brandId
     this.addAuthStateChangeListener((authUser) => this.handleAuthStateChanged(authUser))
     onAuthStateChanged(this.auth, (authUser) => {
-      this.authStateChangeListeners.forEach((callback) => callback(authUser))
+      this.dispatchAuthStateChange(authUser)
     })
+  }
+
+  // Debounced dispatcher. See CROSS_TAB_NULL_DEBOUNCE_MS comment for
+  // why. Users are dispatched immediately; nulls wait, and are
+  // suppressed if a user arrives (or if auth.currentUser has recovered
+  // by the time the timer fires).
+  private dispatchAuthStateChange(authUser: AuthUser | null): void {
+    if (authUser) {
+      if (this.pendingNullDispatchTimeout !== null) {
+        clearTimeout(this.pendingNullDispatchTimeout)
+        this.pendingNullDispatchTimeout = null
+      }
+      this.authStateChangeListeners.forEach((callback) => callback(authUser))
+      return
+    }
+    if (this.pendingNullDispatchTimeout !== null) {
+      return
+    }
+    this.pendingNullDispatchTimeout = setTimeout(() => {
+      this.pendingNullDispatchTimeout = null
+      if (this.auth.currentUser !== null) {
+        logger.logDebug('Suppressed transient null: auth.currentUser recovered before debounce fired')
+        return
+      }
+      this.authStateChangeListeners.forEach((callback) => callback(null))
+    }, CROSS_TAB_NULL_DEBOUNCE_MS)
   }
 
   addAuthStateChangeListener(callback: (authUser: AuthUser | null) => void): () => void {


### PR DESCRIPTION
Fixes the \"opening a new tab logs out the existing tab\" bug the user reported.

## Symptom

Occasionally, opening a second tab to the store while a first tab is logged in flips the first tab to logged-out. Non-deterministic; depends on Firebase's cross-tab IndexedDB race.

## Diagnosis

Firebase's cross-tab auth sync (via \`browserLocalPersistence\` + IndexedDB) can fire a transient \`null\` on an *already-loaded* tab when a *second* tab initializes Firebase. IndexedDB lock/read contention causes Firebase to briefly perceive no persisted user, fires \`onAuthStateChanged(null)\` to all tabs, then re-reads and re-fires the real user within tens to hundreds of ms.

Root cause is Firebase-internal (multi-tab IDB contention, not our code). The existing code in \`firebase.ts::_init\` already awaits \`setPersistence\` + \`authStateReady\` before creating \`AuthManager\` to swallow the *initial boot-time* null (comment at line 336-339 acknowledges this). But it doesn't address transient nulls that fire later on already-registered subscribers when a second tab opens.

## Fix

\`AuthManager\` now debounces dispatches of \`null\` to subscribers by \`CROSS_TAB_NULL_DEBOUNCE_MS\` (500 ms). New private method \`dispatchAuthStateChange(authUser)\`:
- **User event**: cancel any pending null dispatch, propagate immediately to all subscribers.
- **Null event**: schedule a timer for 500 ms. If nothing intervenes, propagate null. If another event comes first, cancel.
- **Timer fires**: re-read \`this.auth.currentUser\` first — if Firebase has recovered without firing a distinct user event, suppress the null and log at debug.

500 ms is well above the observed recovery window (<100 ms in practice) and low enough that explicit signOut still feels responsive (shopper just clicked; a half-second is fine).

No public API changes. \`addAuthStateChangeListener\` still fires its callback immediately with \`auth.currentUser\` on registration — that's a stable synchronous read post-\`authStateReady\`, not a Firebase event.

## Test plan

- [x] \`npm run check\` clean.
- [x] \`npm run test:e2e\` clean (7/7).
- [x] Live-tested against demo with \`?tfr-source=local-demo\`: opened tab A, logged in, opened tab B — tab A stayed logged in.
- [x] Regression: explicit signOut from the fitting-room overlay still logs the user out (with the 500 ms delay, which should be imperceptible).

## Follow-up

If 500 ms proves too aggressive in the wild (rare cross-tab races that take longer to recover), bump the constant. Nothing else needs to change.