### PR TITLE
Regenerate types for System Info responses

### DIFF
--- a/src/api/gen/responses.ts
+++ b/src/api/gen/responses.ts
@@ -884,6 +884,30 @@ export interface StyleCategoryGroup {
 }
 
 //////////
+// source: system_info.go
+
+/**
+ * SystemInfoEntry is one entry in the System Info listing
+ * (GET /v1/system-info). It carries no content — the dashboard fetches the
+ * Markdown per entry via GET /v1/system-info/:key.
+ */
+export interface SystemInfoEntry {
+  key: string;
+  title: string;
+  description: string;
+}
+/**
+ * SystemInfoEntryContent is a single entry's rendered content
+ * (GET /v1/system-info/:key). Markdown is GitHub-flavored and rendered
+ * client-side.
+ */
+export interface SystemInfoEntryContent {
+  key: string;
+  title: string;
+  markdown: string;
+}
+
+//////////
 // source: user.go
 
 export interface User {


### PR DESCRIPTION
## What

Regenerates `src/api/gen/responses.ts` to add `SystemInfoEntry` and `SystemInfoEntryContent`, matching the new backend endpoints (TheFittingRoom/tfr-backend#863).

The SDK doesn't consume these types yet — this keeps the generated client contract from lagging the backend, per the repo's gen-types convention. Generated diff only; no hand-written code.

**Depends on tfr-backend#863** (merge that first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)