### PR TITLE
Fall back to default size/colorway when a stored CSA id is stale

### DIFF
--- a/src/components/overlays/fitting-room/index.tsx
+++ b/src/components/overlays/fitting-room/index.tsx
@@ -172,12 +172,17 @@ export default function FittingRoomOverlay({ preselectExternalId }: FittingRoomO
     return out
   }, [resolved, selectedExternalIds])
 
-  // Auto-size-rec: when an item is selected and has no colorwaySizeAssetId yet,
-  // pick the recommended size for its currently-stored color preference and
-  // write back via updateFittingRoomItem so the choice persists.
+  // Auto-size-rec: when a selected item has no colorwaySizeAssetId yet, OR its
+  // stored id has gone stale (item.needsResize — the CSA is no longer in the
+  // current size rec, e.g. the style was re-saved/re-published and the row was
+  // replaced, or the colorway/size was removed), fall back to the DEFAULT: the
+  // recommended size for the item's stored colour preference, or the first
+  // colorway when that colour is gone (findRecommendedColorSize handles both).
+  // Write back via updateFittingRoomItem so the corrected choice persists and a
+  // stale id is never sent to VTO.
   const ensureSizeForItem = useCallback(
     (item: ResolvedFittingRoomItem) => {
-      if (item.storage.colorwaySizeAssetId != null) {
+      if (item.storage.colorwaySizeAssetId != null && !item.needsResize) {
         return
       }
       const productData = buildVtoProductDataFromResolved(item)

--- a/src/lib/fitting-room-outfit.ts
+++ b/src/lib/fitting-room-outfit.ts
@@ -214,7 +214,11 @@ function makeOutfitItem(r: ResolvedFittingRoomItem, forceUntuck: boolean): Outfi
   if (!r.styleCategory) {
     return null
   }
-  if (r.storage.colorwaySizeAssetId == null) {
+  // No chosen CSA yet, OR the stored CSA is stale (needsResize — no longer in
+  // the current size rec). Drop it from the wire request so an invalid id never
+  // reaches VTO; ensureSizeForItem re-resolves it to the default and the next
+  // build picks up the corrected id.
+  if (r.storage.colorwaySizeAssetId == null || r.needsResize) {
     return null
   }
   // Tuckable is a per-CHILD trait; the container's own category

--- a/tests/e2e/fixtures/host.html
+++ b/tests/e2e/fixtures/host.html
@@ -85,7 +85,21 @@
           environment: cfg.environment ?? 'demo',
           debug: true,
           currentProduct,
-          productLookup: async () => [],
+          // Resolve the current product by handle so fitting-room items that
+          // reference it (the stored-selection path) get merchant data. Real
+          // storefronts back this with a Storefront API lookup; tests only need
+          // the one seeded product. Extend with cfg.productCatalog if a test
+          // needs to look up products other than the current one.
+          productLookup: async (handles) => {
+            const catalog = []
+            if (cfg.currentProduct) {
+              catalog.push(cfg.currentProduct)
+            }
+            if (Array.isArray(cfg.productCatalog)) {
+              catalog.push(...cfg.productCatalog)
+            }
+            return handles.map((h) => catalog.find((p) => p.handle === h)).filter(Boolean)
+          },
           addToCart: async (externalId, opts) => {
             window.__TFR_TEST_LAST_ADD__ = { externalId, opts }
           },

--- a/tests/e2e/stale-csa-fallback.spec.ts
+++ b/tests/e2e/stale-csa-fallback.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+import { bootSdk } from './helpers/boot'
+import {
+  TEST_BRAND_ID,
+  TEST_PRODUCT_EXTERNAL_ID,
+  TEST_PRODUCT_HANDLE,
+  TEST_SEEDED_STYLE,
+  TEST_SIZE_FIT_RECOMMENDATION,
+  TEST_UID,
+  TEST_VTO_COMPOSITION,
+} from './fixtures/seed'
+
+// Regression guard for the stale-stored-CSA fallback. A merchant's product page
+// persists a "fitting room item" that references a colorway-size-asset by its
+// integer id. If the style is re-saved/re-published and that CSA row is
+// replaced, the stored id goes stale — it's no longer in the current size rec.
+// Before the fix the SDK sent the stale id straight to POST /v1/vto-compositions
+// and the render broke. Now `resolveItem` flags it (needsResize), the wire-item
+// builder drops it so the stale id is never posted, and `ensureSizeForItem`
+// re-resolves it to the DEFAULT — the recommended size + first/preferred
+// colorway — persisting the correction. This test seeds a stale id, selects the
+// item, and asserts the VTO request carries the recommended CSA (5001), not the
+// stale one, and that the correction was written back to storage.
+
+// From TEST_SIZE_FIT_RECOMMENDATION: recommended size M -> CSA 5001.
+const RECOMMENDED_CSA_ID = 5001
+// An id deliberately absent from the size rec (available CSAs are 5001, 5002).
+const STALE_CSA_ID = 999999
+
+// Minimal style-category wiring so the stored item resolves a styleCategory and
+// its rail card becomes selectable (a card with no category renders disabled).
+// TEST_SEEDED_STYLE.style_category_name is 'tshirt'.
+const TSHIRT_CATEGORY = {
+  name: 'tshirt',
+  label: 'T-Shirts',
+  label_singular: 'T-Shirt',
+  group: 'tops',
+  layer_order: 10,
+  tuckable: false,
+  layer_order_untucked: 10,
+  sleeve_selection: 'not_applicable',
+  measurement_locations: [],
+  additional_locations_full_sleeves: [],
+  includes: [],
+  excludes: [],
+  is_container: false,
+}
+const TOPS_GROUP = { name: 'tops', label: 'Tops', same_group_default: 'exclude', display_order: 1 }
+
+test('fitting room: a stale stored CSA id falls back to the recommended size + first colorway', async ({ page }) => {
+  const capturedVtoItems: Array<{ colorway_size_asset_id: number; untucked?: boolean }[]> = []
+
+  // Seed a fitting-room item whose stored CSA id is stale (before the SDK boots
+  // and reads localStorage). Bucketed by (brandId, uid) exactly as the SDK writes.
+  await page.addInitScript(
+    ({ brandId, uid, externalId, handle, staleCsa }) => {
+      const item = { externalId, handle, size: 'M', color: 'Blue', colorwaySizeAssetId: staleCsa, addedAt: 1 }
+      const data = { [String(brandId)]: { [uid]: [item] } }
+      window.localStorage.setItem('tfr:fitting-room:v1', JSON.stringify(data))
+    },
+    {
+      brandId: TEST_BRAND_ID,
+      uid: TEST_UID,
+      externalId: TEST_PRODUCT_EXTERNAL_ID,
+      handle: TEST_PRODUCT_HANDLE,
+      staleCsa: STALE_CSA_ID,
+    },
+  )
+
+  await bootSdk(page, {
+    firestoreDocs: { styles: { 'test-style': TEST_SEEDED_STYLE } },
+    apiOverrides: {
+      sizeRecommendation: (route) => route.fulfill({ json: TEST_SIZE_FIT_RECOMMENDATION }),
+      styleCategories: (route) => route.fulfill({ json: [TSHIRT_CATEGORY] }),
+      styleCategoryGroups: (route) => route.fulfill({ json: [TOPS_GROUP] }),
+      vtoComposition: async (route) => {
+        const body = route.request().postDataJSON() as { items: (typeof capturedVtoItems)[number] }
+        capturedVtoItems.push(body.items)
+        await route.fulfill({ json: TEST_VTO_COMPOSITION })
+      },
+    },
+  })
+
+  // Open the overlay and select the stored (stale) item. The card body button's
+  // accessible name is the product name.
+  await page.getByRole('button', { name: 'Fitting Room', exact: true }).click()
+  await page.getByRole('button', { name: /Test Product/i }).click()
+
+  // The VTO request must carry the recommended CSA, never the stale id.
+  await expect.poll(() => capturedVtoItems.length, { timeout: 8000 }).toBeGreaterThanOrEqual(1)
+  const ids = capturedVtoItems[0].map((i) => i.colorway_size_asset_id)
+  expect(ids).toContain(RECOMMENDED_CSA_ID)
+  expect(ids).not.toContain(STALE_CSA_ID)
+
+  // The correction was persisted back to storage, so a reload doesn't re-stale.
+  const persistedCsaId = await page.evaluate(
+    ({ brandId, uid }) => {
+      const raw = window.localStorage.getItem('tfr:fitting-room:v1')
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw) as Record<string, Record<string, { colorwaySizeAssetId: number | null }[]>>
+      return parsed[String(brandId)]?.[uid]?.[0]?.colorwaySizeAssetId ?? null
+    },
+    { brandId: TEST_BRAND_ID, uid: TEST_UID },
+  )
+  expect(persistedCsaId).toBe(RECOMMENDED_CSA_ID)
+})


### PR DESCRIPTION
## Summary

A merchant's product page persists a **fitting room item** that references a colorway-size-asset by integer id. When the style is re-saved/re-published and that CSA row is replaced, the stored id goes **stale** — no longer in the current size rec. The SDK sent the stale id straight to `POST /v1/vto-compositions`, so VTO **failed** instead of degrading gracefully.

We fall back to the **default**: the size-recommendation size + the first (or stored-preferred) colorway.

## Why it was low-risk

The SDK already had every piece — they just weren't wired together for the stale-**but-non-null** case:
- `resolveItem` computes **`needsResize`** — validates the stored id against the size-rec catalog (`available_sizes[*].colorway_size_assets[*].id`) with **no round-trip**.
- `findRecommendedColorSize` / `ensureSizeForItem` already compute **and persist** the default (recommended size + preferred-or-first colorway) — but `ensureSizeForItem` only fired when the stored id was `null`.

## Changes

1. **`ensureSizeForItem`** (`overlays/fitting-room/index.tsx`) — re-resolve to the default when `item.needsResize`, not only when the id is `null`. Persists the corrected id via `updateFittingRoomItem` so the fix survives a reload.
2. **`makeOutfitItem`** (`lib/fitting-room-outfit.ts`) — drop an item from the wire request when `needsResize`, so a stale id is **never posted** even during the brief correction window; the next build picks up the corrected id.

## Test

`tests/e2e/stale-csa-fallback.spec.ts` — seeds a stale stored CSA, opens the overlay, selects the item, and asserts the VTO request carries the **recommended** CSA (`5001`), never the stale `999999`, and that the correction is **persisted** to storage. Verified **fails-without** (VTO posts `999999`) / **passes-with**.

Also extends the e2e host fixture's `productLookup` to resolve the current product by handle — additive, and it unlocks testing the fitting-room stored-selection path (previously only quick-view, which recomputes from scratch and was already immune). `npm run check` + `npm run build` clean; full e2e suite (8 tests) green.

## Notes

- **Related backend fix**: TheFittingRoom/tfr-backend#873 closed one *source* of stale ids (a SKU rename used to delete+recreate the CSA row). This SDK change is defense-in-depth against the remaining vectors (colorway delete+add, size edits, republish).
- Quick-view is unaffected — it never reads a stored CSA id.
- Demo verification requires a genuinely stale stored id, which is hard to stage manually; covered by the e2e instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)